### PR TITLE
Missing sentry metadata.yaml

### DIFF
--- a/amulet/charm.py
+++ b/amulet/charm.py
@@ -64,9 +64,9 @@ class Builder(object):
                 if not os.path.exists(hook_file):
                     os.symlink(self.hook, hook_file)
 
-        self._write_metadata()
+        self.write_metadata()
 
-    def _write_metadata(self):
+    def write_metadata(self):
         metadata = yaml.dump(self.metadata, default_flow_style=False)
         with open(os.path.join(self.charm, 'metadata.yaml'), 'w') as m:
             m.write(metadata)

--- a/amulet/deployer.py
+++ b/amulet/deployer.py
@@ -178,6 +178,7 @@ class Deployment(object):
             self.add(rel_sentry.metadata['name'], rel_sentry.charm)
             self.expose(rel_sentry.metadata['name'])
             self._sentries[rel_sentry.metadata['name']] = rel_sentry
+            rel_sentry.write_metadata()
             self.relationship_sentry = rel_sentry
 
         relations = copy.deepcopy(self.relations)

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -131,3 +131,12 @@ class DeployerTests(unittest.TestCase):
                   'wordpress': {'branch': 'lp:charms/wordpress'}}, 'series':
                   'precise', 'relations': [['mysql:db', 'wordpress:db']]}}
         self.assertEqual(schema, d.schema())
+
+    def test_build_sentries_writes_relationship_sentry_metadata(self):
+        """Even if there are no relations the metadata.yaml is written."""
+        d = Deployment(juju_env='gojuju', sentries=True)
+
+        d.build_sentries()
+
+        self.assertIn('metadata.yaml',
+                      os.listdir(d.relationship_sentry.charm))


### PR DESCRIPTION
Write the metadata.yaml when the relation_sentry is created, rather than waiting until a relationship is added.

Trying to run an amulet test kept resulting in: http://paste.ubuntu.com/6587980/

The other error this fixes is the incorrect exception being caught for python3 subprocess.

The test takes a bit of time to run unfortunately (1sec). From a very brief look, it's mostly during the creation of the Builder(). We could avoid it by mocking the Builder and just asserting that write_metadata() is called. Let me know what you prefer.
