### PR TITLE
Use safe_dump when saving charm metadata yaml

### DIFF
--- a/amulet/charm.py
+++ b/amulet/charm.py
@@ -67,7 +67,7 @@ class Builder(object):
         self.write_metadata()
 
     def write_metadata(self):
-        metadata = yaml.dump(self.metadata, default_flow_style=False)
+        metadata = yaml.safe_dump(self.metadata, default_flow_style=False)
         with open(os.path.join(self.charm, 'metadata.yaml'), 'w') as m:
             m.write(metadata)
 

--- a/amulet/deployer.py
+++ b/amulet/deployer.py
@@ -15,6 +15,10 @@ from . import sentry
 from .charm import Builder
 
 
+_default_sentry_template = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)), 'charms/sentry')
+
+
 class Deployment(object):
     def __init__(self, juju_env=None, series='precise', sentries=True,
                  juju_deployer='juju-deployer',
@@ -31,8 +35,7 @@ class Deployment(object):
         self._sentries = {}
         self.use_sentries = sentries
         self.sentry_blacklist = []
-        self.sentry_template = sentry_template or os.path.join(
-            os.path.abspath(os.path.dirname(__file__)), 'charms/sentry')
+        self.sentry_template = sentry_template or _default_sentry_template
         self.relationship_sentry = None
 
         self.deployer = juju_deployer

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -1,0 +1,17 @@
+
+import unittest
+import yaml
+
+from amulet.charm import Builder
+from amulet.deployer import _default_sentry_template
+
+
+class BuilderTest(unittest.TestCase):
+
+    def test_does_not_create_yaml_tags(self):
+        """Instead of creating yaml safe_load will refuse, fail at write"""
+        class customstr(str):
+            """A custom Python type yaml would serialise tagged"""
+        self.assertIn("!!", yaml.dump(customstr("a")))
+        builder = Builder(customstr("acharm"), _default_sentry_template)
+        self.assertRaises(yaml.YAMLError, builder.write_metadata)


### PR DESCRIPTION
Ran into an issue using amulet with Python 2 where a unicode
string crept into the sentry metadata which resulted in a
tagged value that broke on juju-deployer loading the file.
