### PR TITLE
Update makefile to hunt for pip/nose bins.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,16 @@
 PY := venv/bin/python
-PIP := venv/local/bin/pip
-NOSE := venv/local/bin/nosetests-3.3
+# If the bin version does not exist look in venv/local/bin
+ifeq ($(wildcard venv/bin/pip),)
+  PIP = venv/local/bin/pip
+else
+  PIP = venv/bin/pip
+endif
+# If the bin version does not exist look in venv/local/bin
+ifeq ($(wildcard venv/bin/nosetests-3.3),)
+  NOSE = venv/local/bin/nosetests-3.3
+else
+  NOSE = venv/bin/nosetests-3.3
+endif
 
 # ###########
 # Build
@@ -41,11 +51,17 @@ sysdeps:
 # Develop
 # ###########
 
-$(NOSE):
+$(NOSE): $(PY)
 	$(PIP) install -r test-requires.txt
 
 .PHONY: test
-test: venv develop $(NOSE)
+test: $(NOSE)
+	make py3test
+
+# This is a private target used to get around finding nose in different paths.
+# Do not call this manually, just use make test.
+.PHONY: py3test
+py3test:
 	@echo Testing Python 3...
 	@$(NOSE) --nologcapture
 


### PR DESCRIPTION
- Check for nose/pip in both venv/bin and venv/local/bin
- Remove the venv and develop dep for the test target since pip won't exist
  until post-install and tries to use the wrong path and files.
- This means tests need to be run after a manually make install which is the
  default target.

git clone
cd amulet
make
make test
