### PR TITLE
More robust running of bzr in a subprocess

### DIFF
--- a/amulet/charm.py
+++ b/amulet/charm.py
@@ -1,10 +1,32 @@
 
+import errno
 import os
 import yaml
 import glob
 import shutil
 import tempfile
 import subprocess
+
+
+def _as_text(bytestring):
+    """Naive conversion of subprocess output to Python string"""
+    return bytestring.decode("utf-8", "replace")
+
+
+def run_bzr(args, working_dir, env=None):
+    """Run a Bazaar command in a subprocess"""
+    try:
+        p = subprocess.Popen(["bzr"] + args, cwd=working_dir, env=env,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
+        raise IOError("bzr not found, do you have Bazaar installed?")
+    out, err = p.communicate()
+    if p.returncode:
+        raise IOError("bzr command failed {!r}:\n"
+            "{}".format(args, _as_text(err)))
+    return _as_text(out)
 
 
 class Builder(object):
@@ -28,12 +50,7 @@ class Builder(object):
         for h in glob.glob(os.path.join(self.charm, 'hooks', '*')):
             os.chmod(h, 0o755)
 
-        with open(os.devnull, 'w') as devnull:
-            try:
-                subprocess.check_call(['bzr', 'init'], cwd=self.charm,
-                                      stdout=devnull, stderr=devnull)
-            except subprocess.CalledProcessError:
-                raise IOError('Unable to create bzr repo')
+        run_bzr(["init"], self.charm)
 
         if subordinate:
             self.require('juju-info', 'juju-info', {'scope': 'container'})
@@ -82,12 +99,5 @@ class Builder(object):
         self.save()
 
     def save(self):
-        with open(os.devnull, 'w') as devnull:
-            try:
-                subprocess.check_call(['bzr', 'add', '.'], cwd=self.charm,
-                                      stdout=devnull, stderr=devnull)
-                subprocess.check_call(['bzr', 'commit', '-m', 'Checkpoint'],
-                                      cwd=self.charm, stdout=devnull,
-                                      stderr=devnull)
-            except subprocess.CalledProcessError:
-                raise IOError('Unable to update bzr repo')
+            run_bzr(["add", "."], self.charm)
+            run_bzr(["commit", "-m" "Checkpoint"], self.charm)

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -1,8 +1,9 @@
 
+import os
 import unittest
 import yaml
 
-from amulet.charm import Builder
+from amulet.charm import Builder, run_bzr
 from amulet.deployer import _default_sentry_template
 
 
@@ -15,3 +16,20 @@ class BuilderTest(unittest.TestCase):
         self.assertIn("!!", yaml.dump(customstr("a")))
         builder = Builder(customstr("acharm"), _default_sentry_template)
         self.assertRaises(yaml.YAMLError, builder.write_metadata)
+
+
+class RunBzrTest(unittest.TestCase):
+
+    def test_run_bzr(self):
+        out = run_bzr(["rocks"], ".")
+        self.assertEquals(out, "It sure does!\n")
+
+    def test_run_bzr_traceback(self):
+        self.assertRaisesRegexp(Exception, "AssertionError: always fails",
+            run_bzr, ["assert-fail"], ".")
+
+    def test_run_bzr_missing(self):
+        env = os.environ.copy()
+        env["PATH"] = ""
+        self.assertRaisesRegexp(Exception, "bzr not found",
+            run_bzr, ["version"], ".", env=env)


### PR DESCRIPTION
Adds a run_bzr helper that makes an effort to do sane things and
reports errors from bzr back up to the amulet level.
