### PR TITLE
Add interactivity test to sysdeps target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ lib/python*/site-packages/aumlet.egg-link:
 
 .PHONY: sysdeps
 sysdeps:
-	sudo apt-get install python3-dev
+	sudo apt-get $(shell tty -s || echo -y) install python3-dev
 
 # ###########
 # Develop


### PR DESCRIPTION
when running in an automated environment (without an interactive terminal), it would help me to have the sysdeps target intelligently insert a "-y" on the apt-get install command line.
