### PR TITLE
Don't add quotes to 'juju set' args

### DIFF
--- a/amulet/deployer.py
+++ b/amulet/deployer.py
@@ -172,7 +172,7 @@ class Deployment(object):
         if self.deployed:
             opts = ['set', service]
             for k, v in options.items():
-                opts.append("%s='%s'" % (k, v))
+                opts.append("%s=%s" % (k, v))
             return juju(opts)
 
         if service not in self.services:


### PR DESCRIPTION
They aren't needed, and end up becoming part of the actual
arg string values since there's no shell to remove them.

Signed-off-by: Tim Van Steenburgh tvansteenburgh@gmail.com
