### PR TITLE
Preserve bundle file service options

### DIFF
--- a/amulet/deployer.py
+++ b/amulet/deployer.py
@@ -68,7 +68,10 @@ class Deployment(object):
             self.add(
                 service,
                 charm=service_config.get('charm'),
-                units=service_config.get('num_units', 1))
+                units=service_config.get('num_units', 1),
+            )
+            if service_config.get('options'):
+                self.configure(service, service_config['options'])
         self.series = schema['series']
         self.relations = schema['relations']
 

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -51,7 +51,8 @@ class DeployerTests(unittest.TestCase):
                   "relations": [["mysql:db", "wordpress:db"]]}}'
         dmap = json.loads(schema)
         with patch.object(d, 'add') as add:
-            d.load(dmap)
+            with patch.object(d, 'configure') as configure:
+                d.load(dmap)
         self.assertEqual(d.juju_env, 'gojuju')
         self.assertEqual(dmap['mybundle']['relations'], d.relations)
         self.assertEqual(dmap['mybundle']['series'], d.series)
@@ -60,6 +61,9 @@ class DeployerTests(unittest.TestCase):
             call('mysql', charm=None, units=1)],
             any_order=True
         )
+        configure.assert_has_calls([
+            call('mysql', {'tuning': 'fastest'}),
+        ])
         d.cleanup()
 
     @patch('amulet.deployer.get_charm')


### PR DESCRIPTION
When a bundle file contains an options dict, configure the service with the options instead of silently dropping them.
