### PR TITLE
Explicitly cast timeout to string

### DIFF
--- a/amulet/deployer.py
+++ b/amulet/deployer.py
@@ -266,7 +266,7 @@ class Deployment(object):
                     '-W', '-L',
                     '-c', s,
                     '-e', self.juju_env,
-                    '-t', timeout + 100,  # ensure we timeout before deployer
+                    '-t', str(timeout + 100),  # ensure we timeout before deployer
                     self.juju_env,
                 ], cwd=self.deployer_dir)
             self.deployed = True


### PR DESCRIPTION
Just realized this fails w/o the explicit type cast.
