### PR TITLE
Be smarter about getting name of the charm under test

### DIFF
--- a/amulet/deployer.py
+++ b/amulet/deployer.py
@@ -4,11 +4,26 @@ import base64
 import shutil
 import subprocess
 import tempfile
+import yaml
 
 from .helpers import default_environment, juju, timeout as unit_timesout
 from .sentry import Talisman
 
 from .charm import get_charm
+
+
+def get_charm_name(dir_):
+    """Given a directory, return the name of the charm in that dir.
+
+    If metadata.yaml exists in the dir, grab the charm name from there.
+    Otherwise, return the name of the dir.
+
+    """
+    try:
+        with open(os.path.join(dir_, 'metadata.yaml')) as f:
+            return yaml.load(f)['name']
+    except:
+        return os.path.basename(dir_)
 
 
 class CharmCache(dict):
@@ -41,7 +56,7 @@ class Deployment(object):
         self.series = series
         self.deployed = False
         self.juju_env = juju_env or default_environment()
-        self.charm_name = os.path.basename(os.getcwd())
+        self.charm_name = get_charm_name(os.getcwd())
 
         self.sentry = None
         self.deployer = juju_deployer

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -3,10 +3,13 @@
 import os
 import unittest
 import json
+import shutil
+import tempfile
 import yaml
 
 from amulet import Deployment
 from amulet.deployer import CharmCache
+from amulet.deployer import get_charm_name
 from amulet.sentry import UnitSentry
 from mock import patch, MagicMock, call
 from collections import OrderedDict
@@ -475,3 +478,23 @@ class CharmCacheTest(unittest.TestCase):
         charm = c.fetch('myservice', 'mytestcharm')
         self.assertEqual(charm, get_charm.return_value)
         get_charm.assert_called_once_with(os.getcwd(), series='precise')
+
+
+class GetCharmNameTest(unittest.TestCase):
+    def setUp(self):
+        self.dir_ = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.dir_)
+
+    def test_name_from_yaml(self):
+        """Charm name pulled from metadata.yaml if it exists"""
+        with open(os.path.join(self.dir_, 'metadata.yaml'), 'w') as f:
+            f.write('name: testcharm')
+
+        self.assertEqual(get_charm_name(self.dir_), 'testcharm')
+
+    def test_name_from_dir(self):
+        """Charm name equals dir name if no metadata.yaml exists"""
+        self.assertEqual(
+            get_charm_name(self.dir_), os.path.basename(self.dir_))


### PR DESCRIPTION
Get the charm name from metadata.yaml if possible, otherwise fall back to dir name. JUJU_TEST_CHARM can still be used to override.
