### PR TITLE
When adding units to already deployed env transform to string

### DIFF
--- a/amulet/deployer.py
+++ b/amulet/deployer.py
@@ -134,7 +134,7 @@ class Deployment(object):
             self.services[service].get('num_units', 1) + units
 
         if self.deployed:
-            juju(['add-unit', service, '-n', units])
+            juju(['add-unit', service, '-n', str(units)])
             self.sentry = Talisman(self.services)
 
     def remove_unit(self, *units):

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -167,8 +167,9 @@ class DeployerTests(unittest.TestCase):
         waiter_status.side_effect = self._make_mock_status(d)
         d.add('charm', units=1)
         d.setup()
-        with patch('amulet.deployer.juju'):
+        with patch('amulet.deployer.juju') as j:
             d.add_unit('charm')
+            j.assert_called_with(['add-unit', 'charm', '-n', '1'])
         self.assertTrue('charm/1' in d.sentry.unit)
         self.assertEqual(2, d.services['charm']['num_units'])
 


### PR DESCRIPTION
Hello,

This patch takes care of transforming the `units` argument passed in `add_units()` to string to let subprocess run `juju add-unit foo -n N` otherwise a TypeError is raised.

Fixes https://bugs.launchpad.net/amulet/+bug/1413385

Best,