### PR TITLE
Add handling charms in github + some refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 *.pyc
 .installed.cfg
 bin

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ venv
 .coverage
 dist
 __pycache__/
+/setuptools-12.2.zip

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ venv
 dist
 __pycache__/
 /setuptools-12.2.zip
+/setuptools-12.3.zip

--- a/amulet/__init__.py
+++ b/amulet/__init__.py
@@ -1,6 +1,13 @@
-
 from .waiter import wait
 
 from .deployer import Deployment
 from .helpers import (
-    TimeoutError, timeout, default_environment, raise_status, SKIP, PASS, FAIL)
+    FAIL,
+    PASS,
+    SKIP,
+    TimeoutError,
+    default_environment,
+    fail_if_timeout,
+    raise_status,
+    timeout,
+)

--- a/amulet/charm.py
+++ b/amulet/charm.py
@@ -61,12 +61,12 @@ def with_series(charm_path, series):
     return charm_path
 
 
-def is_branch(path):
+def is_branch(path, control_dirs=set(('.bzr', '.git'))):
     """Test to see if this path is a supported bzr branch.
 
     May be bzr or git.
     """
-    for control_dir in ('.bzr', ):
+    for control_dir in control_dirs:
         if os.path.exists(os.path.join(path, control_dir)):
             return True
     return False

--- a/amulet/charm.py
+++ b/amulet/charm.py
@@ -157,7 +157,7 @@ class GitCharm(VCSCharm):
         self.relations = {}
         self.provides = {}
         self.requires = {}
-        self.fork = fork
+        self.branch = self.fork = fork
         self._parse(self._raw)
 
     @reify

--- a/amulet/charm.py
+++ b/amulet/charm.py
@@ -21,7 +21,7 @@ class CharmCache(dict):
     def get_charm(charm_path, branch=None, series='precise'):
         if charm_path.startswith('lp:'):
             return LaunchpadCharm(charm_path)
-        elif branch.startswith('lp:'):
+        elif branch and branch.startswith('lp:'):
             return LaunchpadCharm(branch)
 
         if charm_path.startswith('local:'):
@@ -30,7 +30,7 @@ class CharmCache(dict):
                     os.environ.get('JUJU_REPOSITORY', ''),
                     charm_path[len('local:'):]))
 
-        if branch.endswith('.git'):
+        if branch and branch.endswith('.git'):
             return GitCharm(branch, name=charm_path)
 
         if os.path.exists(os.path.expanduser(charm_path)):
@@ -42,11 +42,12 @@ class CharmCache(dict):
         return self.fetch(service)
 
     def fetch(self, service, charm=None, branch=None, series='precise'):
+        charm_ = charm
         charm = super(CharmCache, self).get(service, None)
         if charm is not None:
             return charm
 
-        charm = charm or service
+        charm = charm_ or service
         charm = os.getcwd() if charm == self.test_charm else charm
         self[service] = self.get_charm(charm,
                                        branch=branch,

--- a/amulet/deployer.py
+++ b/amulet/deployer.py
@@ -343,6 +343,3 @@ class Deployment(object):
             relations.append(rel)
 
         return relations
-
-    def cleanup(self):
-        shutil.rmtree(self.deployer_dir)

--- a/amulet/helpers.py
+++ b/amulet/helpers.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-
+import functools
 import os
 import sys
 import yaml
@@ -166,3 +166,19 @@ def default_environment(juju_home=None):
             raise ValueError('No default environment specified.')
 
         return next(iter(envs['environments'].keys()))
+
+
+class reify(object):
+    def __init__(self, func):
+        self.func = func
+        try:
+            functools.update_wrapper(self, func)
+        except:
+            pass
+
+    def __get__(self, inst, obtype=None):
+        if inst is None:
+            return self
+        out = self.func(inst)
+        setattr(inst, self.func.__name__, out)
+        return out

--- a/amulet/helpers.py
+++ b/amulet/helpers.py
@@ -179,6 +179,18 @@ class reify(object):
     def __get__(self, inst, obtype=None):
         if inst is None:
             return self
+
         out = self.func(inst)
         setattr(inst, self.func.__name__, out)
         return out
+
+
+@contextmanager
+def fail_if_timeout(seconds):
+    try:
+        yield
+    except TimeoutError:
+        message = 'Unable to set up environment in %d seconds.' % seconds
+        raise_status(FAIL, msg=message)
+    except:
+        raise

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ from setuptools import setup
 install_requires = [
     'requests',
     'charmworldlib',
-    'PyYAML'
+    'PyYAML',
+    'path.py'
 ]
 
 tests_require = [

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -6,13 +6,12 @@ import yaml
 
 from mock import patch, call
 
-from amulet.charm import (
-    run_bzr,
-    LocalCharm,
-    setup_bzr,
-    get_charm,
-    is_branch,
-)
+from amulet.charm import CharmCache
+from amulet.charm import LocalCharm
+from amulet.charm import is_branch
+from amulet.charm import run_bzr
+from amulet.charm import setup_bzr
+
 
 
 class RunBzrTest(unittest.TestCase):

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -105,14 +105,68 @@ class GetCharmTest(unittest.TestCase):
     def test_local(self):
         with patch('amulet.charm.LocalCharm') as LocalCharm:
             with patch.dict('amulet.charm.os.environ', {}):
-                get_charm('local:precise/mycharm')
+                CharmCache.get_charm('local:precise/mycharm')
                 LocalCharm.assert_called_once_with('precise/mycharm')
                 LocalCharm.reset_mock()
 
             with patch.dict('amulet.charm.os.environ', {
                     'JUJU_REPOSITORY': '~/charms'}):
-                get_charm('local:precise/mycharm')
+                CharmCache.get_charm('local:precise/mycharm')
                 LocalCharm.assert_called_once_with('~/charms/precise/mycharm')
+
+
+class CharmCacheTest(unittest.TestCase):
+    def test_init(self):
+        c = CharmCache('mytestcharm')
+        self.assertEqual(c.test_charm, 'mytestcharm')
+
+    def test_getitem_service(self):
+        c = CharmCache('mytestcharm')
+        with patch.object(c, 'get_charm') as get_charm:
+            charm = c['myservice']
+            self.assertEqual(charm, get_charm.return_value)
+            get_charm.assert_called_once_with('myservice', branch=None,
+                                              series='precise')
+            get_charm.reset_mock()
+            charm2 = c['myservice']
+            self.assertEqual(charm, charm2)
+            self.assertFalse(get_charm.called)
+
+    def test_getitem_testcharm(self):
+        c = CharmCache('mytestcharm')
+        with patch.object(c, 'get_charm') as get_charm:
+            charm = c['mytestcharm']
+            self.assertEqual(charm, get_charm.return_value)
+            get_charm.assert_called_once_with(os.getcwd(), branch=None,
+                                              series='precise')
+
+    def test_fetch_service(self):
+        c = CharmCache('mytestcharm')
+        with patch.object(c, 'get_charm') as get_charm:
+            charm = c.fetch('myservice')
+            self.assertEqual(charm, get_charm.return_value)
+            get_charm.assert_called_once_with('myservice', branch=None,
+                                              series='precise')
+
+        get_charm.reset_mock()
+        charm2 = c['myservice']
+        self.assertEqual(charm, charm2)
+        self.assertFalse(get_charm.called)
+
+    def test_fetch_charm(self):
+        c = CharmCache('mytestcharm')
+        with patch.object(c, 'get_charm') as get_charm:
+            charm = c.fetch('myservice', 'anothercharm')
+            self.assertEqual(charm, get_charm.return_value)
+            get_charm.assert_called_once_with('anothercharm', branch=None, series='precise')
+
+    def test_fetch_testcharm(self):
+        c = CharmCache('mytestcharm')
+        with patch.object(c, 'get_charm') as get_charm:
+            charm = c.fetch('myservice', 'mytestcharm')
+            self.assertEqual(charm, get_charm.return_value)
+            get_charm.assert_called_once_with(os.getcwd(), branch=None,
+                                              series='precise')
 
 
 class IsBranchTest(unittest.TestCase):

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -42,7 +42,6 @@ class DeployerTests(unittest.TestCase):
         self.assertEqual('gojuju', d.juju_env)
         self.assertEqual({}, d.services)
         self.assertEqual([], d.relations)
-        d.cleanup()
 
     def test_load(self):
         d = Deployment(juju_env='gojuju')
@@ -68,9 +67,8 @@ class DeployerTests(unittest.TestCase):
         configure.assert_has_calls([
             call('mysql', {'tuning': 'fastest'}),
         ])
-        d.cleanup()
 
-    @patch('amulet.deployer.get_charm')
+    @patch('amulet.charm.CharmCache.get_charm')
     def test_add(self, mcharm):
         charm = mcharm.return_value
         charm.subordinate = False
@@ -82,9 +80,8 @@ class DeployerTests(unittest.TestCase):
         d.add('charm')
         self.assertEqual({'charm': {'charm': 'cs:precise/charm',
                                     'num_units': 1}}, d.services)
-        d.cleanup()
 
-    @patch('amulet.deployer.get_charm')
+    @patch('amulet.charm.CharmCache.get_charm')
     def test_add_branch(self, mcharm):
         charm = mcharm.return_value
         charm.subordinate = False
@@ -95,9 +92,8 @@ class DeployerTests(unittest.TestCase):
         d.add('bar', 'cs:~foo/baz')
         self.assertEqual({'bar': {'branch': 'lp:~foo/charms/precise/baz/trunk',
                                   'num_units': 1}}, d.services)
-        d.cleanup()
 
-    @patch('amulet.deployer.get_charm')
+    @patch('amulet.charm.CharmCache.get_charm')
     def test_add_units(self, mcharm):
         charm = mcharm.return_value
         charm.subordinate = False
@@ -108,9 +104,8 @@ class DeployerTests(unittest.TestCase):
         d.add('charm', units=2)
         self.assertEqual({'charm': {'branch': 'lp:charms/charm',
                                     'num_units': 2}}, d.services)
-        d.cleanup()
 
-    @patch('amulet.deployer.get_charm')
+    @patch('amulet.charm.CharmCache.get_charm')
     def test_add_constraints(self, mcharm):
         charm = mcharm.return_value
         charm.subordinate = False
@@ -128,7 +123,6 @@ class DeployerTests(unittest.TestCase):
                                     'constraints':
                                     'cpu-power=0 cpu-cores=4 mem=512M',
                                     'num_units': 2}}, d.services)
-        d.cleanup()
 
     def _make_mock_status(self, d):
         def _mock_status(juju_env):
@@ -152,7 +146,7 @@ class DeployerTests(unittest.TestCase):
     @patch('amulet.helpers.environments')
     @patch('amulet.sentry.waiter.status')
     @patch('amulet.deployer.subprocess')
-    @patch('amulet.deployer.get_charm')
+    @patch('amulet.charm.CharmCache.get_charm')
     def test_add_unit(self, mcharm, subprocess, waiter_status, environments,
                       upload_scripts):
         charm = mcharm.return_value
@@ -164,6 +158,7 @@ class DeployerTests(unittest.TestCase):
         environments.return_value = yaml.safe_load(RAW_ENVIRONMENTS_YAML)
 
         d = Deployment(juju_env='gojuju')
+
         waiter_status.side_effect = self._make_mock_status(d)
         d.add('charm', units=1)
         d.setup()
@@ -173,13 +168,11 @@ class DeployerTests(unittest.TestCase):
         self.assertTrue('charm/1' in d.sentry.unit)
         self.assertEqual(2, d.services['charm']['num_units'])
 
-        d.cleanup()
-
     @patch.object(UnitSentry, 'upload_scripts')
     @patch('amulet.helpers.environments')
     @patch('amulet.sentry.waiter.status')
     @patch('amulet.deployer.subprocess')
-    @patch('amulet.deployer.get_charm')
+    @patch('amulet.charm.CharmCache.get_charm')
     def test_add_unit_error(self, mcharm, subprocess, waiter_status,
                             environments, upload_scripts):
         def mock_unit_error(f, service, unit_name):
@@ -210,9 +203,8 @@ class DeployerTests(unittest.TestCase):
             self.assertRaisesRegexp(
                 Exception, 'Error on unit charm/1: hook failed: install',
                 d.add_unit, 'charm')
-        d.cleanup()
 
-    @patch('amulet.deployer.get_charm')
+    @patch('amulet.charm.CharmCache.get_charm')
     def test_remove_unit(self, get_charm):
         d = Deployment(juju_env='gojuju')
         d.add('charm')
@@ -226,7 +218,7 @@ class DeployerTests(unittest.TestCase):
         self.assertFalse('charm/0' in sentry.unit)
         self.assertEqual(0, d.services['charm']['num_units'])
 
-    @patch('amulet.deployer.get_charm')
+    @patch('amulet.charm.CharmCache.get_charm')
     def test_remove_service(self, get_charm):
         d = Deployment(juju_env='gojuju')
         d.add('charm')
@@ -242,7 +234,7 @@ class DeployerTests(unittest.TestCase):
         self.assertFalse('charm' in d.services)
         self.assertEqual(0, len(d.relations))
 
-    @patch('amulet.deployer.get_charm')
+    @patch('amulet.charm.CharmCache.get_charm')
     def test_remove(self, get_charm):
         d = Deployment(juju_env='gojuju')
         d.add('charm1')
@@ -258,21 +250,20 @@ class DeployerTests(unittest.TestCase):
             remove_unit.assert_called_once_with('charm1/0')
             remove_service.assert_called_once_with('charm2')
 
-    @patch('amulet.deployer.get_charm')
+    @patch('amulet.charm.CharmCache.get_charm')
     def test_remove_aliases(self, get_charm):
         d = Deployment
         self.assertEqual(d.destroy_unit, d.remove_unit)
         self.assertEqual(d.destroy_service, d.remove_service)
         self.assertEqual(d.destroy, d.remove)
 
-    @patch('amulet.deployer.get_charm')
+    @patch('amulet.charm.CharmCache.get_charm')
     def test_add_error(self, mcharm):
         d = Deployment(juju_env='gojuju')
         d.add('bar')
         self.assertRaises(ValueError, d.add, 'bar')
-        d.cleanup()
 
-    @patch('amulet.deployer.get_charm')
+    @patch('amulet.charm.CharmCache.get_charm')
     def test_relate(self, mcharm):
         a = mcharm.return_value
         a.provides = {'f': {'interface': 'test'}}
@@ -283,33 +274,28 @@ class DeployerTests(unittest.TestCase):
         d.add('foo')
         d.relate('foo:f', 'bar:b')
         self.assertEqual(d.relations, [['foo:f', 'bar:b']])
-        d.cleanup()
 
     def test_relate_too_few(self):
         d = Deployment(juju_env='gojuju')
         self.assertRaises(LookupError, d.relate, 'foo:f')
-        d.cleanup()
 
     def test_relate_no_relation(self):
         d = Deployment(juju_env='gojuju')
         self.assertRaises(ValueError, d.relate, 'foo', 'bar:a')
-        d.cleanup()
 
-    @patch('amulet.deployer.get_charm')
+    @patch('amulet.charm.CharmCache.get_charm')
     def test_relate_relation_nonexist(self, mcharm):
         d = Deployment(juju_env='gojuju')
         d.add('bar')
         d.add('foo')
 
         self.assertRaises(ValueError, d.relate, 'foo:f', 'bar:b')
-        d.cleanup()
 
     def test_relate_not_deployed(self):
         d = Deployment(juju_env='gojuju')
         self.assertRaises(ValueError, d.relate, 'foo:f', 'bar:a')
-        d.cleanup()
 
-    @patch('amulet.deployer.get_charm')
+    @patch('amulet.charm.CharmCache.get_charm')
     def test_configure(self, mcharm):
         charm = mcharm.return_value
         charm.subordinate = False
@@ -327,15 +313,13 @@ class DeployerTests(unittest.TestCase):
                            'options': {'tuning': 'optimized',
                                        'wp-content': 'f',
                                        'port': 100}}}, d.services)
-        d.cleanup()
 
     def test_configure_not_deployed(self):
         d = Deployment(juju_env='gojuju')
         self.assertRaises(ValueError, d.configure, 'wordpress',
                           {'tuning': 'optimized'})
-        d.cleanup()
 
-    @patch('amulet.deployer.get_charm')
+    @patch('amulet.charm.CharmCache.get_charm')
     def test_expose(self, mcharm):
         charm = mcharm.return_value
         charm.subordinate = False
@@ -351,14 +335,12 @@ class DeployerTests(unittest.TestCase):
                 {'branch': 'lp:~charmers/charms/precise/wordpress/trunk',
                  'num_units': 1,
                  'expose': True}}, d.services)
-        d.cleanup()
 
     def test_expose_not_deployed(self):
         d = Deployment(juju_env='gojuju')
         self.assertRaises(ValueError, d.expose, 'wordpress')
-        d.cleanup()
 
-    @patch('amulet.deployer.get_charm')
+    @patch('amulet.charm.CharmCache.get_charm')
     def test_schema(self, mcharm):
         wpmock = MagicMock()
         mysqlmock = MagicMock()
@@ -395,19 +377,16 @@ class DeployerTests(unittest.TestCase):
             'relations': [['mysql:db', 'wordpress:db']],
         }}
         self.assertEqual(schema, d.schema())
-        d.cleanup()
 
     @patch.dict('os.environ', {'JUJU_TEST_CHARM': 'charmbook'})
     def test_juju_test_charm(self):
         d = Deployment(juju_env='gogo')
         self.assertEqual('charmbook', d.charm_name)
-        d.cleanup()
 
     def test_add_post_deploy(self):
         d = Deployment(juju_env='gogo')
         d.deployed = True
         self.assertRaises(NotImplementedError, d.add, 'mysql')
-        d.cleanup()
 
     def test_relate_before_service_deployed(self):
         d = Deployment(juju_env='gogo')
@@ -416,18 +395,15 @@ class DeployerTests(unittest.TestCase):
             d.relate('mysql:db', 'wordpress:db')
             self.assertEqual(
                 'Can not relate, service not deployed yet', str(e))
-        d.cleanup()
 
     def test_unrelate_not_enough(self):
         d = Deployment(juju_env='gogo')
         self.assertRaises(LookupError, d.unrelate, 'mysql')
-        d.cleanup()
 
     def test_unrelate_too_many(self):
         d = Deployment(juju_env='gogo')
         self.assertRaises(LookupError, d.unrelate,
                           'mysql', 'wordpress', 'charm')
-        d.cleanup()
 
     def test_unrelate_bad_service_format(self):
         d = Deployment(juju_env='gogo')
@@ -436,7 +412,6 @@ class DeployerTests(unittest.TestCase):
             d.unrelate('mysql', 'wordpress')
             self.assertEqual(
                 str(e), 'All relations must be explicit, service:relation')
-        d.cleanup()
 
     @patch('amulet.deployer.juju')
     def test_unrelate(self, mj):
@@ -448,14 +423,12 @@ class DeployerTests(unittest.TestCase):
             call(['remove-relation',
                   'mysql:db', 'charm:db']),
             ])
-        d.cleanup()
 
     def test_unrelate_post_deploy(self):
         d = Deployment(juju_env='gogo')
         with self.assertRaises(ValueError) as e:
             d.unrelate('mysql:db', 'wordpress:db')
             self.assertEqual('Relation does not exist', str(e))
-        d.cleanup()
 
     @patch('amulet.deployer.juju')
     def test_remove_unit(self, mj):
@@ -464,37 +437,30 @@ class DeployerTests(unittest.TestCase):
         d.deployed = True
         d.remove_unit('mysql/1')
         mj.assert_called_with(['remove-unit', 'mysql/1'])
-        d.cleanup()
 
     def test_remove_unit_env_not_setup(self):
         d = Deployment(juju_env='gogo')
         d.add('mysql', units=2)
         self.assertRaises(NotImplementedError, d.remove_unit, 'mysql/0')
-        d.cleanup()
 
     def test_remove_unit_no_args(self):
         d = Deployment(juju_env='gogo')
         d.add('mysql', units=2)
         d.deployed = True
         self.assertRaises(ValueError, d.remove_unit)
-        d.cleanup()
 
     def test_remove_unit_not_a_unit(self):
         d = Deployment(juju_env='gogo')
         d.add('mysql', units=2)
         d.deployed = True
         self.assertRaises(ValueError, d.remove_unit, 'mysql/1', 'lolk')
-        d.cleanup()
 
     def test_remove_unit_not_deployed(self):
         d = Deployment(juju_env='gogo')
         d.add('mysql', units=2)
         d.deployed = True
         self.assertRaises(ValueError, d.remove_unit, 'wordpress/1')
-        d.cleanup()
 
-    def test_setup(self):
-        pass
 
 
 

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -59,9 +59,18 @@ class DeployerTests(unittest.TestCase):
         self.assertEqual(dmap['mybundle']['relations'], d.relations)
         self.assertEqual(dmap['mybundle']['series'], d.series)
         add.assert_has_calls([
-            call('wordpress', charm=None, units=1, constraints=None),
-            call('mysql', charm=None, units=1,
-                 constraints={'mem': '2G', 'cpu-cores': '2'})],
+            call('wordpress',
+                 series='raring',
+                 units=1,
+                 branch='lp:~charmers/charms/precise/wordpress/trunk',
+                 constraints=None,
+                 charm=None),
+            call('mysql',
+                 series='raring',
+                 units=1,
+                 branch='lp:~charmers/charms/precise/mysql/trunk',
+                 constraints={'mem': '2G', 'cpu-cores': '2'},
+                 charm=None)],
             any_order=True
         )
         configure.assert_has_calls([

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -497,55 +497,7 @@ class DeployerTests(unittest.TestCase):
         pass
 
 
-class CharmCacheTest(unittest.TestCase):
-    def test_init(self):
-        c = CharmCache('mytestcharm')
-        self.assertEqual(c.test_charm, 'mytestcharm')
 
-    @patch('amulet.deployer.get_charm')
-    def test_getitem_service(self, get_charm):
-        c = CharmCache('mytestcharm')
-        charm = c['myservice']
-        self.assertEqual(charm, get_charm.return_value)
-        get_charm.assert_called_once_with('myservice', series='precise')
-
-        get_charm.reset_mock()
-        charm2 = c['myservice']
-        self.assertEqual(charm, charm2)
-        self.assertFalse(get_charm.called)
-
-    @patch('amulet.deployer.get_charm')
-    def test_getitem_testcharm(self, get_charm):
-        c = CharmCache('mytestcharm')
-        charm = c['mytestcharm']
-        self.assertEqual(charm, get_charm.return_value)
-        get_charm.assert_called_once_with(os.getcwd(), series='precise')
-
-    @patch('amulet.deployer.get_charm')
-    def test_fetch_service(self, get_charm):
-        c = CharmCache('mytestcharm')
-        charm = c.fetch('myservice')
-        self.assertEqual(charm, get_charm.return_value)
-        get_charm.assert_called_once_with('myservice', series='precise')
-
-        get_charm.reset_mock()
-        charm2 = c['myservice']
-        self.assertEqual(charm, charm2)
-        self.assertFalse(get_charm.called)
-
-    @patch('amulet.deployer.get_charm')
-    def test_fetch_charm(self, get_charm):
-        c = CharmCache('mytestcharm')
-        charm = c.fetch('myservice', 'anothercharm')
-        self.assertEqual(charm, get_charm.return_value)
-        get_charm.assert_called_once_with('anothercharm', series='precise')
-
-    @patch('amulet.deployer.get_charm')
-    def test_fetch_testcharm(self, get_charm):
-        c = CharmCache('mytestcharm')
-        charm = c.fetch('myservice', 'mytestcharm')
-        self.assertEqual(charm, get_charm.return_value)
-        get_charm.assert_called_once_with(os.getcwd(), series='precise')
 
 
 class GetCharmNameTest(unittest.TestCase):

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -60,12 +60,14 @@ class DeployerTests(unittest.TestCase):
         self.assertEqual(dmap['mybundle']['series'], d.series)
         add.assert_has_calls([
             call('wordpress',
+                 placement=None,
                  series='raring',
                  units=1,
                  branch='lp:~charmers/charms/precise/wordpress/trunk',
                  constraints=None,
                  charm=None),
             call('mysql',
+                 placement=None,
                  series='raring',
                  units=1,
                  branch='lp:~charmers/charms/precise/mysql/trunk',

--- a/tests/test_gitcharm.py
+++ b/tests/test_gitcharm.py
@@ -1,0 +1,6 @@
+import unittest
+
+class TestGitCham(TestCase):
+    def makeone(self, fork="http://github.com/juju-solutions/kraken.git", name="gitty"):
+        from amulet.charm import GitCharm
+        return GitCharm(fork, name)

--- a/tests/test_gitcharm.py
+++ b/tests/test_gitcharm.py
@@ -1,6 +1,9 @@
 import unittest
 
-class TestGitCham(TestCase):
-    def makeone(self, fork="http://github.com/juju-solutions/kraken.git", name="gitty"):
+
+class TestGitCham(unittest.TestCase):
+
+    def makeone(self, fork="http://github.com/juju-solutions/kraken.git",
+                name="gitty"):
         from amulet.charm import GitCharm
         return GitCharm(fork, name)


### PR DESCRIPTION
Includes:
- new gitcharm charm class
 - pass along to: & branch: key as part of service block
 - boilerplate reduction for test writing for bundles
    * `fail_if_timeout` contextmanager
    * `from_bundle` factory
 - sprinkling of path.py love
 - refactor `amulet.deployer.Deployment.setup`

   Make use of context managers and path.py to simplify flow.  Uses
   tempdir to control flow wrt leaving debugging if there are errors.
   Preserves semantics of cleanup arg.  Adds logging statements.