### PR TITLE
Fix wait() logic wrt timeout

### DIFF
--- a/amulet/sentry.py
+++ b/amulet/sentry.py
@@ -2,6 +2,7 @@ import glob
 import json
 import os
 import subprocess
+import time
 
 import pkg_resources
 
@@ -254,15 +255,16 @@ class Talisman(object):
             raise
 
     def wait(self, timeout=300):
-        #for unit in self.unit:
         ready = False
         try:
+            now = time.time()
             with helpers.timeout(timeout):
                 # Make sure we're in a 'started' state across the board
-                waiter.wait(timeout=timeout)
-                while not ready:
+                while not ready and now + timeout < time.time():
+                    waiter.wait(timeout=15)
                     for unit in self.unit.keys():
                         status = self.unit[unit].juju_agent()
+
                         # Check if we have a hook key and it's not None
                         if status is None:
                             ready = False
@@ -272,6 +274,7 @@ class Talisman(object):
                             break
                         else:
                             ready = True
+
         except:
             raise
 

--- a/tests/functional/test_sentry.py
+++ b/tests/functional/test_sentry.py
@@ -7,7 +7,7 @@ class TestDeployment(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.deployment = amulet.Deployment(series='trusty')
+        cls.deployment = amulet.Deployment(series='precise')
 
         cls.deployment.add('nagios')
         cls.deployment.add('haproxy')


### PR DESCRIPTION
This PR addresses lp:1430488. 

The `waiter.wait` blocks for the full duration of the timeout, and `helpers.timeout` creates a signal-based timeout that's triggered when the timeout expires. This lead to `juju_agent()` being run against a unit still installing, which would throw an exception.

I made `waiter.wait` block for a smaller, arbitrary value of time (15 seconds), check the unit status, and repeat until it's ready or the timeout is expired.