### PR TITLE
test: Add test for add_unit

### DIFF
--- a/tests/functional/test_sentry.py
+++ b/tests/functional/test_sentry.py
@@ -35,6 +35,14 @@ class TestDeployment(unittest.TestCase):
             'echo more-contents > /tmp/amulet-sub-test;'
         )
 
+
+    def test_add_unit(self):
+         self.deployment.add_unit('haproxy')
+         haproxy = self.deployment.sentry['haproxy/1']
+         self.assertEqual('1', haproxy.info['unit'])
+         self.assertEqual('haproxy/1', haproxy.info['unit_name'])
+
+
     def test_info(self):
         self.assertTrue('public-address' in self.nagios.info)
         self.assertEqual('nagios', self.nagios.info['service'])


### PR DESCRIPTION
I'm still seeing the problem when I run bundletester on my ubuntu-repository-cache charm.

The problem here is not that the timeout needs to be longer. The behavior suggests that Talisman.__init__() returns from wait_for_status() and progresses to UnitSentry.fromunitdata() which calls UnitSentry.upload_scripts() and attempts an scp prior to the unit actually being ready, because we're seeing the scp failure when this error presents itself. Once we get this working I see a problem having a timeout of 5 minutes in the add_unit that is not configurable as the ubuntu-repository-cache charm can take a while to spool up a unit.

If you look at tests/function/test_sentry.py (or any other testing for amulet) there is no test for add_unit after Deployer.setup is called to deploy the first N units.

This test should currently fail with:
$ make test
make py3test
make[1]: Entering directory '/home/ubuntu/amulet'
Testing Python 3...
2015-04-16 16:13:34 Starting deployment of amazon-test-foo
2015-04-16 16:13:35 Deploying services...
2015-04-16 16:13:36  Deploying service haproxy using cs:trusty/haproxy-6
2015-04-16 16:13:44  Deploying service nagios using cs:trusty/nagios-6
2015-04-16 16:13:52  Deploying service rsyslog-forwarder using cs:trusty/rsyslog-forwarder-0
2015-04-16 16:14:02 Config specifies num units for subordinate: rsyslog-forwarder
2015-04-16 16:20:59 Adding relations...
2015-04-16 16:21:00  Adding relation nagios:website <-> haproxy:reverseproxy
2015-04-16 16:21:00  Adding relation nagios:juju-info <-> rsyslog-forwarder:juju-info
2015-04-16 16:22:01 Deployment complete in 508.16 seconds
ERROR exit status 1 (Warning: Permanently added '54.234.249.124' (ECDSA) to the list of known hosts.
ERROR subprocess encountered error code 1
ssh_exchange_identification: Connection closed by remote host
lost connection)
E.....F..............................................................................................
======================================================================
ERROR: test_add_unit (tests.functional.test_sentry.TestDeployment)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ubuntu/amulet/tests/functional/test_sentry.py", line 39, in test_add_unit
    self.deployment.add_unit('haproxy')
  File "/home/ubuntu/amulet/amulet/deployer.py", line 157, in add_unit
    self.sentry = Talisman(self.services)
  File "/home/ubuntu/amulet/amulet/sentry.py", line 168, in __init__
    self.unit[unit] = UnitSentry.fromunitdata(unit, unit_data)
  File "/home/ubuntu/amulet/amulet/sentry.py", line 58, in fromunitdata
    unitsentry.upload_scripts()
  File "/home/ubuntu/amulet/amulet/sentry.py", line 71, in upload_scripts
    subprocess.check_call(cmd.split())
  File "/usr/lib/python3.4/subprocess.py", line 561, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['juju', 'scp', '/home/ubuntu/amulet/amulet/unit-scripts/amulet/directory_listing.py', 'haproxy/1:/tmp/amulet']' returned non-zero exit status 1
