### PR TITLE
Make amulet scripts work regardless of working dir

### DIFF
--- a/amulet/charm.py
+++ b/amulet/charm.py
@@ -8,6 +8,7 @@ import yaml
 
 from .helpers import reify
 from .helpers import run_bzr
+from .helpers import get_charm_directory
 from charmworldlib.charm import Charm
 from path import path
 from path import tempdir
@@ -51,7 +52,8 @@ class CharmCache(dict):
             return charm
 
         charm = charm_ or service
-        charm = os.getcwd() if charm == self.test_charm else charm
+        charm = get_charm_directory() if charm == self.test_charm else charm
+
         self[service] = self.get_charm(charm,
                                        branch=branch,
                                        series=series)

--- a/amulet/deployer.py
+++ b/amulet/deployer.py
@@ -10,7 +10,12 @@ import yaml
 from path import path
 from path import tempdir
 
-from .helpers import default_environment, juju, timeout as unit_timesout
+from .helpers import (
+    default_environment,
+    juju,
+    get_charm_directory,
+    timeout as unit_timesout,
+)
 from .sentry import Talisman
 from .charm import CharmCache
 
@@ -44,7 +49,7 @@ class Deployment(object):
         self.series = series
         self.deployed = False
         self.juju_env = juju_env or default_environment()
-        self.charm_name = get_charm_name(os.getcwd())
+        self.charm_name = get_charm_name(get_charm_directory())
 
         self.sentry = None
         self.deployer = path(juju_deployer)
@@ -304,7 +309,8 @@ class Deployment(object):
             include_token = 'include-base64://'
             if type(v) is str and v.startswith(include_token):
                 v = v.replace(include_token, '')
-                with open(os.path.join(os.getcwd(), 'tests', v)) as f:
+                charm_directory = get_charm_directory()
+                with open(os.path.join(charm_directory, 'tests', v)) as f:
                     v = base64.b64encode(f.read())
                 service['options'][k] = v
 

--- a/amulet/helpers.py
+++ b/amulet/helpers.py
@@ -194,3 +194,7 @@ def fail_if_timeout(seconds):
         raise_status(FAIL, msg=message)
     except:
         raise
+
+
+def get_charm_directory():
+    return os.path.abspath(os.path.join(sys.path[0], os.pardir))


### PR DESCRIPTION
Amulet would not properly find the current charm unless the script was
invoked from the charm's root folder. To make less assumptions, this
patch adds a helper function that finds the current charm's directory
regardless of the invokers current working directory.