### PR TITLE
Don't configure logging in the library code

### DIFF
--- a/amulet/deployer.py
+++ b/amulet/deployer.py
@@ -14,7 +14,6 @@ from .helpers import default_environment, juju, timeout as unit_timesout
 from .sentry import Talisman
 from .charm import CharmCache
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
This inadvertently added a second handler (and therefore, duplicate logging output) to tests that were configuring their own logging.