### PR TITLE
Fix sentry tools no longer defaulting to charm dir

### DIFF
--- a/amulet/sentry.py
+++ b/amulet/sentry.py
@@ -137,16 +137,18 @@ class UnitSentry(Sentry):
             raise subprocess.CalledProcessError(p.returncode, cmd, output)
         return output.decode('utf8').strip(), p.returncode
 
-    def _run_unit_script(self, cmd):
+    def _run_unit_script(self, cmd, working_dir=None):
+        if working_dir is None:
+            working_dir = '/var/lib/juju/agents/unit-{service}-{unit}/charm'.format(**self.info)
         cmd = "/tmp/amulet/{}".format(cmd)
-        output, return_code = self.ssh(cmd)
+        output, return_code = self.ssh('cd {} ; {}'.format(working_dir, cmd))
         if return_code == 0:
             return json.loads(output)
         else:
             raise IOError(output)
 
     def juju_agent(self):
-        return self._run_unit_script("juju_agent.py")
+        return self._run_unit_script("juju_agent.py", working_dir=".")
 
     def relation(self, from_rel, to_rel):
         this_unit = '{service}/{unit}'.format(**self.info)

--- a/tests/functional/test_sentry.py
+++ b/tests/functional/test_sentry.py
@@ -61,6 +61,8 @@ class TestDeployment(unittest.TestCase):
                 'mode': '0100644',
             },
         )
+        stat = self.nagios.file_stat('metadata.yaml')
+        self.assertTrue(stat.pop('mtime'))
 
     def test_file_contents(self):
         path = '/tmp/amulet-test/test-file'
@@ -68,6 +70,7 @@ class TestDeployment(unittest.TestCase):
             self.nagios.file_contents(path),
             'contents\n',
         )
+        self.assertIn('nagios', self.nagios.file_contents('metadata.yaml'))
 
     def test_subordinate_file_contents(self):
         path = '/tmp/amulet-sub-test'
@@ -75,6 +78,7 @@ class TestDeployment(unittest.TestCase):
             self.rsyslogfwd.file_contents(path),
             'more-contents\n',
         )
+        self.assertIn('rsyslog', self.rsyslogfwd.file_contents('metadata.yaml'))
 
     def test_directory_stat(self):
         path = '/tmp/amulet-test'
@@ -94,6 +98,8 @@ class TestDeployment(unittest.TestCase):
                 'mode': '040755',
             },
         )
+        stat = self.nagios.directory_stat('hooks')
+        self.assertTrue(stat.pop('mtime'))
 
     def test_directory_listing(self):
         path = '/tmp/amulet-test'
@@ -103,6 +109,7 @@ class TestDeployment(unittest.TestCase):
                 'directories': ['test-dir'],
             },
         )
+        self.assertIn('install', self.nagios.directory_listing('hooks')['files'])
 
     def test_relation(self):
         nagios_info = self.nagios.relation(


### PR DESCRIPTION
With the change to use 'juju ssh' in lieu of 'juju run' for the sentry
helpers, the default working directory is no longer the charm dir.  Work
around this by explicitly changing the directory (though not for
juju_agent, since the explicit charm dir interferes with it watching for
hooks).