### PR TITLE
Fix amulet file helpers not using root

### DIFF
--- a/amulet/sentry.py
+++ b/amulet/sentry.py
@@ -141,7 +141,7 @@ class UnitSentry(Sentry):
         if working_dir is None:
             working_dir = '/var/lib/juju/agents/unit-{service}-{unit}/charm'.format(**self.info)
         cmd = "/tmp/amulet/{}".format(cmd)
-        output, return_code = self.ssh('cd {} ; {}'.format(working_dir, cmd))
+        output, return_code = self.ssh('cd {} ; sudo {}'.format(working_dir, cmd))
         if return_code == 0:
             return json.loads(output)
         else:

--- a/tests/functional/test_sentry.py
+++ b/tests/functional/test_sentry.py
@@ -28,7 +28,8 @@ class TestDeployment(unittest.TestCase):
         cls.haproxy = cls.deployment.sentry['haproxy/0']
         cls.rsyslogfwd = cls.deployment.sentry['rsyslog-forwarder/0']
         cls.nagios.run(
-            'mkdir -p /tmp/amulet-test/test-dir;'
+            'sudo mkdir -p /tmp/amulet-test/test-dir;'
+            'sudo chmod go-rx /tmp/amulet-test;'
             'echo contents > /tmp/amulet-test/test-file;'
         )
         cls.rsyslogfwd.run(
@@ -95,7 +96,7 @@ class TestDeployment(unittest.TestCase):
                 'size': stat['size'],
                 'uid': 0,
                 'gid': 0,
-                'mode': '040755',
+                'mode': '040700',
             },
         )
         stat = self.nagios.directory_stat('hooks')


### PR DESCRIPTION
The switch from 'juju ssh' to 'juju run' to prevent blocking caused the
helpers to fail against root-owned protected files / dirs.