### PR TITLE
Refactored wait logic to work better on Juju>=1.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ coverage: $(NOSE)
 
 .PHONY: lint
 lint:
-	@find $(sources) -type f \( -iname '*.py' ! -iname '__init__.py' ! -iwholename '*venv/*' \) -print0 | xargs -r0 flake8
+	@find $(sources) -type f \( -iname '*.py' ! -iname '__init__.py' ! -iwholename '*venv/*' \) -print0 | xargs -r0 flake8 --max-line-length=120
 
 .PHONY: check
 check: test lint

--- a/amulet/deployer.py
+++ b/amulet/deployer.py
@@ -10,7 +10,7 @@ import yaml
 from path import path
 from path import tempdir
 
-from .helpers import default_environment, juju, timeout_alarm as unit_timesout
+from .helpers import default_environment, juju, timeout as unit_timesout
 from .sentry import Talisman
 from .charm import CharmCache
 

--- a/amulet/deployer.py
+++ b/amulet/deployer.py
@@ -158,7 +158,7 @@ class Deployment(object):
             if not isinstance(constraints, dict):
                 raise ValueError('Constraints must be specified as a dict')
 
-            r = ["%s=%s" % (k, v) for k, v in constraints.items()]
+            r = ['%s=%s' % (K, V) for K, V in constraints.items()]
             service['constraints'] = " ".join(r)
 
         return service

--- a/amulet/deployer.py
+++ b/amulet/deployer.py
@@ -10,7 +10,7 @@ import yaml
 from path import path
 from path import tempdir
 
-from .helpers import default_environment, juju, timeout as unit_timesout
+from .helpers import default_environment, juju, timeout_alarm as unit_timesout
 from .sentry import Talisman
 from .charm import CharmCache
 

--- a/amulet/helpers.py
+++ b/amulet/helpers.py
@@ -72,14 +72,18 @@ def juju(args, env=None):
     return _as_text(out) if out else None
 
 
-def timeout(seconds):
+def timeout_gen(seconds):
     """
     Return a counting generator that raises a :class:`TimeoutError` after
     a number of seconds.
 
-    Note, this is non-preemptive.  That is, it will only check for timeout
-    between iterations.  If you need a preemptive timeout, see
-    :func:`timeout_alarm`.
+    Note, this is non-preemptive; that is, it will only check for timeout
+    between iterations.  This means that it is guaranteed to not timeout
+    in the middle of doing its work / checking, which makes it more
+    deterministic and easier to debug, but also means that you must ensure
+    that the block does not contain an infinite loop or blocking system
+    call that needs to be preempted.  If you need a preemptive timeout, see
+    :func:`timeout`.
 
     :param float seconds: Number of seconds after which to timeout.
 
@@ -106,7 +110,7 @@ def timeout(seconds):
 
 
 @contextmanager
-def timeout_alarm(seconds):
+def timeout(seconds):
     def signal_handler(signum, frame):
         sys.stderr.write('Timeout occurred, printing juju status...')
         sys.stderr.write(juju(['status']))

--- a/amulet/sentry.py
+++ b/amulet/sentry.py
@@ -331,7 +331,7 @@ class Talisman(object):
                         return False
             return True
 
-        for i in helpers.timeout(timeout):
+        for i in helpers.timeout_gen(timeout):
             if check_status(juju_env, services):
                 return waiter.status(juju_env)
 
@@ -349,9 +349,6 @@ class Talisman(object):
             for service_name in self.service_names:
                 service = status.get(service_name, {})
                 for unit_name, unit in service.items():
-                    if unit['workload-status']:
-                        if unit['workload-status']['current'] not in ('active', 'unknown'):
-                            return False
                     if unit['agent-status']:
                         if unit['agent-status']['current'] != 'idle':
                             return False
@@ -364,7 +361,7 @@ class Talisman(object):
                             return False
             return True
 
-        for i in helpers.timeout(timeout):
+        for i in helpers.timeout_gen(timeout):
             if check_status():
                 return
 
@@ -416,7 +413,7 @@ class Talisman(object):
             return messages
 
         matcher = StatusMessageMatcher()
-        for i in helpers.timeout(timeout):
+        for i in helpers.timeout_gen(timeout):
             status = self.get_status()
             for service, expected in messages.items():
                 actual = get_messages(service, status)

--- a/amulet/sentry.py
+++ b/amulet/sentry.py
@@ -2,11 +2,16 @@ import glob
 import json
 import os
 import subprocess
+from datetime import datetime
 
 import pkg_resources
 
 from . import waiter
 from . import helpers
+
+
+# number of seconds an agent must be idle to be considered quiescent
+IDLE_THRESHOLD = 30
 
 
 class SentryError(Exception):
@@ -184,14 +189,14 @@ class UnitSentry(Sentry):
 
 # Possibly use to build out instead of having code in setup()?
 class Talisman(object):
-    def __init__(self, services, rel_sentry='relation-sentry', juju_env=None):
+    def __init__(self, services, rel_sentry='relation-sentry', juju_env=None, timeout=300):
+        self.service_names = services
         self.unit = {}
         self.service = {}
 
-        if not juju_env:
-            juju_env = helpers.default_environment()
+        self.juju_env = juju_env or helpers.default_environment()
 
-        status = self.wait_for_status(juju_env, services)
+        status = self.wait_for_status(self.juju_env, services, timeout)
 
         for service in services:
             if service not in status['services']:
@@ -260,6 +265,40 @@ class Talisman(object):
 
         return unit_sentries
 
+    def get_status(self, juju_env=None):
+        """
+        Get status of all units, normalized
+        to make it a bit easier to work with.
+        """
+        status = waiter.status(juju_env or self.juju_env)
+        normalized = {}
+        for service_name, service in status['services'].items():
+            if 'units' not in service:
+                continue
+            normalized.setdefault(service_name, {})
+            for unit_name, unit in service['units'].items():
+                machine = status['machines'].get(unit.get('machine'), {})
+                normalized[service_name][unit_name] = {
+                    'machine-state': machine.get('agent-state'),
+                    'public-address': unit.get('public-address'),
+                    'workload-status': unit.get('workload-status', {}),
+                    'agent-status': unit.get('agent-status', {}),
+                    'agent-state': unit.get('agent-state'),
+                    'agent-state-info': unit.get('agent-state-info'),
+                }
+                for sub_name, sub in unit.get('subordinates', {}).items():
+                    sub_service = sub_name.split('/')[0]
+                    normalized.setdefault(sub_service, {})
+                    normalized[sub_service][sub_name] = {
+                        'machine-state': machine.get('agent-state'),
+                        'public-address': sub.get('public-address'),
+                        'workload-status': sub.get('workload-status', {}),
+                        'agent-status': sub.get('agent-status', {}),
+                        'agent-state': sub.get('agent-state'),
+                        'agent-state-info': sub.get('agent-state-info'),
+                    }
+        return normalized
+
     def wait_for_status(self, juju_env, services, timeout=300):
         """Return env status, but only after all units have a
         public-address assigned and are in a 'started' state.
@@ -272,31 +311,29 @@ class Talisman(object):
         available for all units before timeout expires.
 
         """
-        try:
-            with helpers.timeout(timeout):
-                while True:
-                    ready = True
-                    status = waiter.status(juju_env)
-                    for service in services:
-                        if 'units' not in status['services'][service]:
-                            continue
-                        for unit, unit_dict in \
-                                status['services'][service]['units'].items():
-                            if 'error' == unit_dict.get('agent-state'):
-                                raise Exception('Error on unit {}: {}'.format(
-                                    unit, unit_dict.get('agent-state-info')))
-                            if 'public-address' not in unit_dict:
-                                ready = False
-                            if 'started' != unit_dict.get('agent-state'):
-                                ready = False
-                    if ready:
-                        return status
-        except helpers.TimeoutError:
-            raise helpers.TimeoutError(
-                'public-address not set for'
-                'all units after {}s'.format(timeout))
-        except:
-            raise
+        def check_status(juju_env, services):
+            status = self.get_status(juju_env)
+            for service_name in services:
+                for unit_name, unit in status[service_name].items():
+                    state = unit['workload-status'].get('current') or unit['agent-state']
+                    message = unit['workload-status'].get('message') or unit['agent-state-info']
+                    if state == 'error':
+                        raise Exception('Error on unit {}: {}'.format(
+                            unit_name, message))
+                    if unit['machine-state'] != 'started':
+                        return False
+                    if not unit['public-address']:
+                        return False
+                    if unit['agent-status']:
+                        if unit['agent-status']['current'] != 'idle':
+                            return False
+                    elif unit['agent-state'] != 'started':
+                        return False
+            return True
+
+        for i in helpers.timeout(timeout):
+            if check_status(juju_env, services):
+                return waiter.status(juju_env)
 
     def wait(self, timeout=300):
         """
@@ -307,27 +344,151 @@ class Talisman(object):
 
         Raises an error if the timeout is exceeded.
         """
-        ready = False
-        try:
-            with helpers.timeout(timeout):
-                while not ready:
-                    for unit in self.unit.keys():
-                        status = self.unit[unit].juju_agent()
+        def check_status():
+            status = self.get_status()
+            for service_name in self.service_names:
+                service = status.get(service_name, {})
+                for unit_name, unit in service.items():
+                    if unit['workload-status']:
+                        if unit['workload-status']['current'] not in ('active', 'unknown'):
+                            return False
+                    if unit['agent-status']:
+                        if unit['agent-status']['current'] != 'idle':
+                            return False
+                        since = datetime.strptime(unit['agent-status']['since'][:20], '%d %b %Y %H:%M:%S')
+                        if (datetime.now() - since).total_seconds() < IDLE_THRESHOLD:
+                            return False
+                    else:
+                        running_hooks = self.unit[unit_name].juju_agent()
+                        if running_hooks is None or running_hooks:
+                            return False
+            return True
 
-                        # Check if we have a hook key and it's not None
-                        if status is None:
-                            ready = False
-                            break
-                        if 'hook' in status and status['hook']:
-                            ready = False
-                            break
-                        else:
-                            ready = True
-        except:
-            raise
+        for i in helpers.timeout(timeout):
+            if check_status():
+                return
+
+    def wait_for_messages(self, messages, timeout=300):
+        """
+        Wait for specific extended status messages to be set via status-set.
+
+        Note that if this is called on an environment that doesn't support
+        extended status (pre Juju 1.24), it will raise a
+        :class:`~amulet.helpers.UnsupportedError` exception.
+
+        :param dict statuses: A mapping of services to an exact message,
+            a regular expression, a set of messages or regular expressions,
+            or a list of messages or regular expressions.  If a single message
+            is given, all units of the service must match.  If a set is given,
+            then each message in the set must match at least one unit.  If a
+            list is given, then there must be a one-to-one match between the
+            messages and the units, though the order doesn't matter.
+        :param int timeout: Number of seconds to wait before timing-out.
+
+        Examples::
+
+            # wait for all units to report "ready"
+            t.wait_for_messages({'ubuntu': 'ready'})
+
+            # wait for all units to report something like "ready"
+            t.wait_for_messages({'ubuntu': re.compile('r..dy')})
+
+            # wait for at least one unit to report "ready"
+            t.wait_for_messages({'ubuntu': {'ready'})
+
+            # wait for all units to report either "ready" or "ok"
+            t.wait_for_messages({'ubuntu': re.compile('ready|ok')})
+
+            # wait for at least one unit to report "ready" and at least one
+            # unit to report "ok"
+            t.wait_for_messages({'ubuntu': {'ready', 'ok'}})
+
+            # wait for one unit to report "ready" and the other to report "ok"
+            # (must be exactly two units)
+            t.wait_for_messages({'ubuntu': ['ready', 'ok']})
+        """
+        def get_messages(service, status):
+            messages = []
+            for unit in status[service].values():
+                if not unit['workload-status']:
+                    raise helpers.UnsupportedError()
+                messages.append(unit['workload-status'].get('message', ''))
+            return messages
+
+        matcher = StatusMessageMatcher()
+        for i in helpers.timeout(timeout):
+            status = self.get_status()
+            for service, expected in messages.items():
+                actual = get_messages(service, status)
+                if not matcher.check(expected, actual):
+                    break
+            else:
+                return
 
     def _sync(self):
         pass
+
+
+class StatusMessageMatcher(object):
+    def check(self, expected, actual):
+        if isinstance(expected, (list, tuple)):
+            return self.check_list(expected, actual)
+        elif isinstance(expected, set):
+            return self.check_set(expected, actual)
+        else:
+            return self.check_messages(expected, actual)
+
+    def check_messages(self, expected, actual):
+        if not actual:
+            return False
+        for a in actual:
+            if not self.check_message(expected, a):
+                return False
+        return True
+
+    def check_set(self, expected, actual):
+        if not actual:
+            return False
+        for e in expected:
+            for a in actual:
+                if self.check_message(e, a):
+                    break  # match, go to next expected
+            else:
+                return False  # no match for this expected (all must match)
+        return True
+
+    def check_list(self, expected, actual):
+        """
+        Lists must match one-to-one.
+
+        pathlogocial: ['ready', 'ready', 'ok'] vs ['ready', 'ok', 'ok']
+        pathlogocial: [r'ready( \(limited\))?', 'ready'] vs ['ready', 'ready (limited)']
+        """
+        if len(actual) != len(expected):
+            return False
+        actual = list(actual)  # copy
+        for e in expected:
+            im = None
+            m = 0
+            for i, a in enumerate(actual):
+                n = self.check_message(e, a)
+                if n > m:  # prefer longest matches
+                    im = i
+                    m = n
+            if im is None:
+                return False  # no matches for this expected (all must match)
+            actual.pop(im)  # remove matched to ensure 1-to-1
+        return True
+
+    def check_message(self, expected, actual):
+        # returns length for longest-match check; 0 -> no match
+        if hasattr(expected, 'search'):
+            m = expected.search(actual)
+            return len(m.group()) if m else 0
+        elif expected == actual:
+            return len(actual)
+        else:
+            return 0
 
 
 class ServiceSentry(Sentry):

--- a/amulet/waiter.py
+++ b/amulet/waiter.py
@@ -36,19 +36,12 @@ def wait(*args, **kwargs):
     if not 'timeout' in kwargs:
         kwargs['timeout'] = 300
 
-    ready = False
-    with timeout(kwargs['timeout']):
-        while not ready:
-            try:
-                raise_for_state(*args, juju_env=kwargs['juju_env'])
-            except TimeoutError:
-                raise
-            except:
-                ready = False
-            else:
-                ready = True
-
-    return True
+    for i in timeout(kwargs['timeout']):
+        try:
+            raise_for_state(*args, juju_env=kwargs['juju_env'])
+            return True
+        except StateError:
+            pass
 
 
 def raise_for_state(*args, **kwargs):

--- a/amulet/waiter.py
+++ b/amulet/waiter.py
@@ -4,7 +4,7 @@ import yaml
 from .helpers import (
     TimeoutError,
     default_environment,
-    timeout,
+    timeout_gen,
     juju,
     JujuVersion,
 )
@@ -36,7 +36,7 @@ def wait(*args, **kwargs):
     if not 'timeout' in kwargs:
         kwargs['timeout'] = 300
 
-    for i in timeout(kwargs['timeout']):
+    for i in timeout_gen(kwargs['timeout']):
         try:
             raise_for_state(*args, juju_env=kwargs['juju_env'])
             return True

--- a/tests/functional/test_sentry.py
+++ b/tests/functional/test_sentry.py
@@ -36,13 +36,11 @@ class TestDeployment(unittest.TestCase):
             'echo more-contents > /tmp/amulet-sub-test;'
         )
 
-
     def test_add_unit(self):
-         self.deployment.add_unit('haproxy')
-         haproxy = self.deployment.sentry['haproxy/1']
-         self.assertEqual('1', haproxy.info['unit'])
-         self.assertEqual('haproxy/1', haproxy.info['unit_name'])
-
+        self.deployment.add_unit('haproxy')
+        haproxy = self.deployment.sentry['haproxy/1']
+        self.assertEqual('1', haproxy.info['unit'])
+        self.assertEqual('haproxy/1', haproxy.info['unit_name'])
 
     def test_info(self):
         self.assertTrue('public-address' in self.nagios.info)

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -8,7 +8,6 @@ import tempfile
 import yaml
 
 from amulet import Deployment
-from amulet.deployer import CharmCache
 from amulet.deployer import get_charm_name
 from amulet.sentry import UnitSentry
 from mock import patch, MagicMock, call
@@ -489,9 +488,9 @@ class DeployerTests(unittest.TestCase):
     @patch('amulet.deployer.juju')
     def test_action_fetch(self, mj):
         mj.side_effect = ['{"Action queued with id": "some-action-id"}',
-                          '{"results":{"key":"value"},"status":"completed",'\
-                          '"timing":{"completed":"2015-07-21 09:05:11 +0300 EEST",'\
-                          '"enqueued":"2015-07-21 09:05:06 +0300 EEST",'\
+                          '{"results":{"key":"value"},"status":"completed",'
+                          '"timing":{"completed":"2015-07-21 09:05:11 +0300 EEST",'
+                          '"enqueued":"2015-07-21 09:05:06 +0300 EEST",'
                           '"started":"2015-07-21 09:05:09 +0300 EEST"}}']
         d = Deployment(juju_env='gojuju')
         d.add('mysql')
@@ -500,13 +499,13 @@ class DeployerTests(unittest.TestCase):
         results = d.action_fetch(uuid)
         self.assertEquals(results, {'key': 'value'})
         mj.assert_has_calls([call(['action', 'do', 'mysql/0', 'run', '--format', 'json', 'action_param=action_value']),
-                         call(['action', 'fetch', 'some-action-id', '--format', 'json', '--wait', '600'])])
+                            call(['action', 'fetch', 'some-action-id', '--format', 'json', '--wait', '600'])])
 
     @patch('amulet.deployer.juju')
     def test_action_fetch_nowait_fail(self, mj):
         mj.side_effect = ['{"Action queued with id": "some-action-id"}',
-                          '{"status":"running",'\
-                          '"timing":{"enqueued":"2015-07-21 09:50:59 +0300 EEST",'\
+                          '{"status":"running",'
+                          '"timing":{"enqueued":"2015-07-21 09:50:59 +0300 EEST",'
                           '"started":"2015-07-21 09:51:04 +0300 EEST"}}']
         d = Deployment(juju_env='gojuju')
         d.add('mysql')
@@ -520,9 +519,9 @@ class DeployerTests(unittest.TestCase):
     @patch('amulet.deployer.juju')
     def test_action_fetch_wait(self, mj):
         mj.side_effect = ['{"Action queued with id": "some-action-id"}',
-                          '{"results":{"key":"value"},"status":"completed",'\
-                          '"timing":{"completed":"2015-07-21 09:05:11 +0300 EEST",'\
-                          '"enqueued":"2015-07-21 09:05:06 +0300 EEST",'\
+                          '{"results":{"key":"value"},"status":"completed",'
+                          '"timing":{"completed":"2015-07-21 09:05:11 +0300 EEST",'
+                          '"enqueued":"2015-07-21 09:05:06 +0300 EEST",'
                           '"started":"2015-07-21 09:05:09 +0300 EEST"}}']
         d = Deployment(juju_env='gojuju')
         d.add('mysql')
@@ -532,7 +531,7 @@ class DeployerTests(unittest.TestCase):
         self.assertEquals(results, {'key': 'value'})
         mj.assert_has_calls([call(['action', 'do', 'mysql/0', 'run', '--format', 'json']),
                              call(['action', 'fetch', 'some-action-id', '--format', 'json', '--wait', '600'])])
-        
+
     @patch('amulet.deployer.juju')
     def test_unrelate(self, mj):
         d = Deployment(juju_env='gogo')
@@ -551,7 +550,7 @@ class DeployerTests(unittest.TestCase):
             self.assertEqual('Relation does not exist', str(e))
 
     @patch('amulet.deployer.juju')
-    def test_remove_unit(self, mj):
+    def test_remove_unit_m(self, mj):
         d = Deployment(juju_env='gogo')
         d.add('mysql', units=2)
         d.deployed = True
@@ -580,10 +579,6 @@ class DeployerTests(unittest.TestCase):
         d.add('mysql', units=2)
         d.deployed = True
         self.assertRaises(ValueError, d.remove_unit, 'wordpress/1')
-
-
-
-
 
 
 class GetCharmNameTest(unittest.TestCase):

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -141,7 +141,7 @@ class DeployerTests(unittest.TestCase):
 
     def _make_mock_status(self, d):
         def _mock_status(juju_env):
-            status = dict(services={})
+            status = dict(services={}, machines={})
             total_units = 1
             for service in d.services:
                 status['services'][service] = dict(units={})
@@ -150,12 +150,20 @@ class DeployerTests(unittest.TestCase):
                     status['services'][service]['units'][
                         '{}/{}'.format(service, unit)] = {
                         'agent-state': 'started',
-                        'public-address': '10.0.3.{}'.format(total_units)}
+                        'public-address': '10.0.3.{}'.format(total_units),
+                        'machine': str(total_units)}
+                    status['machines'][str(total_units)] = {
+                        'agent-state': 'started',
+                    }
             status['services']['relation-sentry'] = {
                 'units': {
                     'relation-sentry/0': {
                         'agent-state': 'started',
-                        'public-address': '10.0.3.1'}}}
+                        'public-address': '10.0.3.1',
+                        'machine': str(total_units+1)}}}
+            status['machines'][str(total_units+1)] = {
+                'agent-state': 'started',
+            }
             return status
         return _mock_status
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,6 +3,7 @@
 import unittest
 import sys
 import yaml
+import time
 
 from amulet.helpers import (
     JujuVersion,
@@ -10,6 +11,8 @@ from amulet.helpers import (
     default_environment,
     juju,
     raise_status,
+    timeout,
+    TimeoutError,
 )
 
 from mock import patch, Mock
@@ -116,6 +119,17 @@ class HelpersTest(unittest.TestCase):
         menvironments.return_value = envs
 
         self.assertRaises(ValueError, default_environment)
+
+    @patch('amulet.helpers.juju', Mock())
+    def test_timeout(self):
+        def case(t):
+            for i in timeout(t):
+                time.sleep(0.2)
+                if i == 1:
+                    return
+        with patch('sys.stderr.write', Mock()):
+            self.assertRaises(TimeoutError, case, 0.1)
+        case(0.5)
 
 
 class JujuTest(unittest.TestCase):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -11,7 +11,7 @@ from amulet.helpers import (
     default_environment,
     juju,
     raise_status,
-    timeout,
+    timeout_gen,
     TimeoutError,
 )
 
@@ -121,9 +121,9 @@ class HelpersTest(unittest.TestCase):
         self.assertRaises(ValueError, default_environment)
 
     @patch('amulet.helpers.juju', Mock(return_value='status'))
-    def test_timeout(self):
+    def test_timeout_gen(self):
         def case(t):
-            for i in timeout(t):
+            for i in timeout_gen(t):
                 time.sleep(0.2)
                 if i == 1:
                     return

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -120,15 +120,14 @@ class HelpersTest(unittest.TestCase):
 
         self.assertRaises(ValueError, default_environment)
 
-    @patch('amulet.helpers.juju', Mock())
+    @patch('amulet.helpers.juju', Mock(return_value='status'))
     def test_timeout(self):
         def case(t):
             for i in timeout(t):
                 time.sleep(0.2)
                 if i == 1:
                     return
-        with patch('sys.stderr.write', Mock()):
-            self.assertRaises(TimeoutError, case, 0.1)
+        self.assertRaises(TimeoutError, case, 0.1)
         case(0.5)
 
 

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -200,7 +200,7 @@ class TalismanTest(unittest.TestCase):
         t.wait(self.timeout)
 
         set_state('workload-status', 'current', 'blocked')
-        self.assertRaises(TimeoutError, t.wait, self.timeout)
+        t.wait(self.timeout)
 
         set_state('workload-status', 'current', 'active')
         set_state('agent-status', 'current', 'executing')

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -1,34 +1,134 @@
+import re
 import unittest
 import yaml
+from datetime import datetime
+from copy import deepcopy
 
 from amulet.sentry import (
     Talisman,
     UnitSentry,
+    StatusMessageMatcher,
 )
-from mock import patch
+from amulet.helpers import (
+    TimeoutError,
+    UnsupportedError,
+)
+from mock import patch, Mock
 
 
 mock_status = yaml.load("""\
+machines:
+  "0":
+    agent-state: started
+    agent-version: 1.24.6.1
+    dns-name: localhost
+    instance-id: localhost
+    series: trusty
+    state-server-member-status: has-vote
+  "1":
+    agent-state: started
+    instance-id: johnsca-local-machine-1
+    series: trusty
+    hardware: arch=amd64
+  "2":
+    agent-state: started
+    instance-id: johnsca-local-machine-1
+    series: trusty
+    hardware: arch=amd64
+  "3":
+    agent-state: pending
+    instance-id: johnsca-local-machine-1
+    series: trusty
+    hardware: arch=amd64
 services:
   meteor:
     units:
       meteor/0:
         public-address: 10.0.3.152
+        workload-status:
+          current: active
+          message: ready
+          since: 24 Sep 2015 16:44:44-04:00
+        agent-status:
+          current: idle
+          since: 24 Sep 2015 16:44:44-04:00
+        machine: "1"
       meteor/1:
         public-address: 10.0.3.177
+        workload-status:
+          current: active
+          message: ready
+          since: 24 Sep 2015 16:44:44-04:00
+        agent-status:
+          current: idle
+          since: 24 Sep 2015 16:44:44-04:00
+        machine: "2"
         subordinates:
           rsyslog-forwarder/0:
             public-address: 10.0.3.115
+            workload-status:
+              current: active
+              message: rsyslog
   relation-sentry:
     units:
       relation-sentry/0:
         public-address: 10.0.3.92
   rsyslog-forwarder:
     charm: cs:trusty/rsyslog-forwarder
+    subordinate-to:
+    - meteor
+  pending:
+    units:
+      pending/0:
+        public-address: 10.0.3.152
+        workload-status:
+          current: unknown
+          since: 24 Sep 2015 16:44:44-04:00
+        agent-status:
+          current: allocating
+          since: 24 Sep 2015 16:44:44-04:00
+        machine: "3"
+  nopublic:
+    units:
+      nopublic/0:
+        workload-status:
+          current: maintainence
+          message: working
+          since: 24 Sep 2015 16:44:44-04:00
+        agent-status:
+          current: executing
+          since: 24 Sep 2015 16:44:44-04:00
+        machine: "2"
+  errord:
+    units:
+      errord/0:
+        public-address: 10.0.3.152
+        workload-status:
+          current: error
+          message: 'hook failed: "install"'
+          since: 24 Sep 2015 16:44:44-04:00
+        agent-status:
+          current: idle
+          since: 24 Sep 2015 16:44:44-04:00
+        machine: "2"
+  old:
+    units:
+      old/0:
+        public-address: 10.0.3.152
+        agent-state: started
+        machine: "2"
+  olderrord:
+    units:
+      olderrord/0:
+        public-address: 10.0.3.152
+        agent-state: error
+        agent-state-info: 'hook failed: "install"'
+        machine: "2"
 """)
 
 
 class TalismanTest(unittest.TestCase):
+    timeout = 0.01
 
     @patch.object(Talisman, 'wait_for_status')
     @patch.object(UnitSentry, 'upload_scripts')
@@ -37,7 +137,7 @@ class TalismanTest(unittest.TestCase):
         default_env.return_value = 'local'
         wait_for_status.return_value = mock_status
 
-        sentry = Talisman(['meteor'])
+        sentry = Talisman(['meteor'], timeout=self.timeout)
 
         self.assertTrue('meteor/0' in sentry.unit)
         self.assertTrue('meteor/1' in sentry.unit)
@@ -49,7 +149,7 @@ class TalismanTest(unittest.TestCase):
         default_env.return_value = 'local'
         wait_for_status.return_value = mock_status
 
-        sentry = Talisman(['meteor'])
+        sentry = Talisman(['meteor'], timeout=self.timeout)
 
         self.assertEqual(sentry['meteor/0'], sentry.unit['meteor/0'])
         self.assertEqual(sentry['meteor'], list(sentry.unit.values()))
@@ -61,6 +161,175 @@ class TalismanTest(unittest.TestCase):
         default_env.return_value = 'local'
         wait_for_status.return_value = mock_status
 
-        sentry = Talisman(['meteor', 'rsyslog-forwarder'])
+        sentry = Talisman(['meteor', 'rsyslog-forwarder'], timeout=self.timeout)
 
         self.assertTrue('rsyslog-forwarder/0' in sentry.unit)
+
+    @patch.object(Talisman, '__init__', Mock(return_value=None))
+    @patch('amulet.helpers.juju', Mock())
+    @patch('amulet.waiter.status')
+    def test_wait_for_status(self, status):
+        status.return_value = mock_status
+        talisman = Talisman([], timeout=self.timeout)
+
+        with patch('sys.stderr.write', Mock()):
+            talisman.wait_for_status('env', ['meteor'], self.timeout)
+            talisman.wait_for_status('env', ['old'], self.timeout)
+
+            self.assertRaises(TimeoutError, talisman.wait_for_status, 'env', ['pending'], self.timeout)
+            self.assertRaises(TimeoutError, talisman.wait_for_status, 'env', ['nopublic'], self.timeout)
+            self.assertRaisesRegexp(Exception, r'Error on unit.*hook failed',
+                                    talisman.wait_for_status, 'env', ['errord'], self.timeout)
+            self.assertRaisesRegexp(Exception, r'Error on unit.*hook failed',
+                                    talisman.wait_for_status, 'env', ['olderrord'], self.timeout)
+
+    @patch('sys.stderr.write', Mock())
+    @patch('amulet.helpers.juju', Mock())
+    @patch('amulet.helpers.default_environment', Mock())
+    @patch.object(UnitSentry, 'upload_scripts', Mock())
+    @patch.object(UnitSentry, 'juju_agent')
+    @patch('amulet.waiter.status')
+    def test_wait(self, _status, juju_agent):
+        status = _status.return_value = deepcopy(mock_status)
+
+        def set_state(which, key, value):
+            status['services']['meteor']['units']['meteor/0'][which][key] = value
+
+        t = Talisman(['meteor'], timeout=self.timeout)
+        t.wait(self.timeout)
+
+        set_state('workload-status', 'current', 'unknown')
+        t.wait(self.timeout)
+
+        set_state('workload-status', 'current', 'blocked')
+        self.assertRaises(TimeoutError, t.wait, self.timeout)
+
+        set_state('workload-status', 'current', 'active')
+        set_state('agent-status', 'current', 'executing')
+        self.assertRaises(TimeoutError, t.wait, self.timeout)
+
+        set_state('agent-status', 'current', 'idle')
+        set_state('agent-status', 'since', datetime.now().strftime('%d %b %Y %H:%M:%S'))
+        self.assertRaises(TimeoutError, t.wait, self.timeout)
+
+        t = Talisman(['old'], timeout=self.timeout)
+        juju_agent.return_value = None
+        self.assertRaises(TimeoutError, t.wait, self.timeout)
+
+        juju_agent.return_value = {'hook': 'foo'}
+        self.assertRaises(TimeoutError, t.wait, self.timeout)
+
+        juju_agent.return_value = {}
+        t.wait(self.timeout)
+
+    @patch('sys.stderr.write', Mock())
+    @patch('amulet.helpers.juju', Mock(side_effect=lambda c: ' '.join(c)))
+    @patch('amulet.helpers.default_environment', Mock())
+    @patch('amulet.waiter.status')
+    def test_wait_for_messages(self, _status):
+        status = _status.return_value = deepcopy(mock_status)
+        t = Talisman([], timeout=self.timeout)
+
+        def set_status(unit, message):
+            service = unit.split('/')[0]
+            status['services'][service]['units'][unit]['workload-status']['message'] = message
+
+        t.wait_for_messages({'meteor': 'ready'}, self.timeout)
+        t.wait_for_messages({'meteor': re.compile('r..dy')}, self.timeout)
+        t.wait_for_messages({'meteor': {'ready'}}, self.timeout)
+        t.wait_for_messages({'meteor': re.compile('ready|ok')}, self.timeout)
+        self.assertRaises(TimeoutError, t.wait_for_messages, {'meteor': {'ready', 'ok'}}, self.timeout)
+        self.assertRaises(TimeoutError, t.wait_for_messages, {'meteor': ['ready', 'ok']}, self.timeout)
+
+        set_status('meteor/0', 'ok')
+        self.assertRaises(TimeoutError, t.wait_for_messages, {'meteor': 'ready'}, self.timeout)
+        self.assertRaises(TimeoutError, t.wait_for_messages, {'meteor': re.compile('r..dy')}, self.timeout)
+        t.wait_for_messages({'meteor': {'ready'}}, self.timeout)
+        t.wait_for_messages({'meteor': re.compile('ready|ok')}, self.timeout)
+        t.wait_for_messages({'meteor': {'ready', 'ok'}}, self.timeout)
+        t.wait_for_messages({'meteor': ['ready', 'ok']}, self.timeout)
+
+        set_status('meteor/1', 'ok')
+        self.assertRaises(TimeoutError, t.wait_for_messages, {'meteor': 'ready'}, self.timeout)
+        self.assertRaises(TimeoutError, t.wait_for_messages, {'meteor': re.compile('r..dy')}, self.timeout)
+        self.assertRaises(TimeoutError, t.wait_for_messages, {'meteor': {'ready'}}, self.timeout)
+        t.wait_for_messages({'meteor': re.compile('ready|ok')}, self.timeout)
+        self.assertRaises(TimeoutError, t.wait_for_messages, {'meteor': {'ready', 'ok'}}, self.timeout)
+        self.assertRaises(TimeoutError, t.wait_for_messages, {'meteor': ['ready', 'ok']}, self.timeout)
+
+        set_status('meteor/0', 'ready')
+        status['services']['meteor']['units']['meteor/2'] = {
+            'workload-status': {
+                'current': 'active',
+                'message': 'working',
+            },
+        }
+        t.wait_for_messages({'meteor': {'ready', 'ok'}})
+        self.assertRaises(TimeoutError, t.wait_for_messages, {'meteor': ['ready', 'ok']}, self.timeout)
+        self.assertRaises(TimeoutError, t.wait_for_messages, {'meteor': ['ready', 'ok', 'ready']}, self.timeout)
+
+        t.wait_for_messages({'rsyslog-forwarder': 'rsyslog'}, self.timeout)
+        self.assertRaises(TimeoutError, t.wait_for_messages, {'rsyslog-forwarder': 'ready'}, self.timeout)
+
+        self.assertRaises(UnsupportedError, t.wait_for_messages, {'old': 'ready'}, self.timeout)
+
+
+class TestStatusMessageMatcher(unittest.TestCase):
+    def test_check(self):
+        m = StatusMessageMatcher()
+        m.check_messages = Mock()
+        m.check_set = Mock()
+        m.check_list = Mock()
+
+        m.check('ready', ['ready'])
+        m.check(re.compile('ready'), ['ready'])
+        self.assertEqual(m.check_messages.call_count, 2)
+
+        m.check({'ready'}, ['ready'])
+        self.assertEqual(m.check_set.call_count, 1)
+
+        m.check(['ready'], ['ready'])
+        m.check(('ready',), ['ready'])
+        self.assertEqual(m.check_list.call_count, 2)
+
+    def test_check_messages(self):
+        m = StatusMessageMatcher()
+
+        assert m.check_messages('ready', ['ready'])
+        assert m.check_messages('ready', ['ready', 'ready'])
+        assert not m.check_messages('ready', ['ready', 'ok'])
+        assert not m.check_messages('ready', [])
+
+    def test_check_set(self):
+        m = StatusMessageMatcher()
+
+        assert m.check_set({'ready'}, ['ready'])
+        assert m.check_set({'ready'}, ['ready', 'ok'])
+        assert m.check_set({'ready', 'ok'}, ['ready', 'ok'])
+        assert not m.check_set({'ready', 'ok'}, ['ready', 'ready'])
+        assert not m.check_set({'ok'}, ['ready', 'ready'])
+        assert not m.check_set({'ready'}, [])
+
+    def test_check_list(self):
+        m = StatusMessageMatcher()
+        r = re.compile
+
+        assert m.check_list(['ready'], ['ready'])
+        assert not m.check_list(['ready', 'ready'], ['ready'])  # too few
+        assert not m.check_list(['ready'], ['ready', 'ready'])  # too many
+        assert m.check_list(['ready', 'ready', 'ok'], ['ready', 'ok', 'ready'])
+        assert not m.check_list(['ready', 'ready', 'ok'], ['ready', 'ok', 'ok'])
+        assert m.check_list([r('ready(ish)?')], ['ready'])
+        assert m.check_list([r('ready(ish)?')], ['readyish'])
+        assert m.check_list([r('ready(ish)?'), 'ready'], ['ready', 'readyish'])  # ambiguous-ish
+        assert m.check_list([r('ready(ish)?'), 'ready'], ['readyish', 'ready'])  # ambiguous-ish
+
+    def test_check_message(self):
+        m = StatusMessageMatcher()
+        r = re.compile
+        self.assertEqual(0, m.check_message('bar', 'foo'))
+        self.assertEqual(3, m.check_message('foo', 'foo'))
+        self.assertEqual(3, m.check_message(r('foo'), 'foo'))
+        self.assertEqual(3, m.check_message(r('foo'), 'foobar'))
+        self.assertEqual(3, m.check_message(r('f..'), 'foo'))
+        self.assertEqual(0, m.check_message(r('b..'), 'foo'))

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -166,25 +166,23 @@ class TalismanTest(unittest.TestCase):
         self.assertTrue('rsyslog-forwarder/0' in sentry.unit)
 
     @patch.object(Talisman, '__init__', Mock(return_value=None))
-    @patch('amulet.helpers.juju', Mock())
+    @patch('amulet.helpers.juju', Mock(return_value='status'))
     @patch('amulet.waiter.status')
     def test_wait_for_status(self, status):
         status.return_value = mock_status
         talisman = Talisman([], timeout=self.timeout)
 
-        with patch('sys.stderr.write', Mock()):
-            talisman.wait_for_status('env', ['meteor'], self.timeout)
-            talisman.wait_for_status('env', ['old'], self.timeout)
+        talisman.wait_for_status('env', ['meteor'], self.timeout)
+        talisman.wait_for_status('env', ['old'], self.timeout)
 
-            self.assertRaises(TimeoutError, talisman.wait_for_status, 'env', ['pending'], self.timeout)
-            self.assertRaises(TimeoutError, talisman.wait_for_status, 'env', ['nopublic'], self.timeout)
-            self.assertRaisesRegexp(Exception, r'Error on unit.*hook failed',
-                                    talisman.wait_for_status, 'env', ['errord'], self.timeout)
-            self.assertRaisesRegexp(Exception, r'Error on unit.*hook failed',
-                                    talisman.wait_for_status, 'env', ['olderrord'], self.timeout)
+        self.assertRaises(TimeoutError, talisman.wait_for_status, 'env', ['pending'], self.timeout)
+        self.assertRaises(TimeoutError, talisman.wait_for_status, 'env', ['nopublic'], self.timeout)
+        self.assertRaisesRegexp(Exception, r'Error on unit.*hook failed',
+                                talisman.wait_for_status, 'env', ['errord'], self.timeout)
+        self.assertRaisesRegexp(Exception, r'Error on unit.*hook failed',
+                                talisman.wait_for_status, 'env', ['olderrord'], self.timeout)
 
-    @patch('sys.stderr.write', Mock())
-    @patch('amulet.helpers.juju', Mock())
+    @patch('amulet.helpers.juju', Mock(return_value='status'))
     @patch('amulet.helpers.default_environment', Mock())
     @patch.object(UnitSentry, 'upload_scripts', Mock())
     @patch.object(UnitSentry, 'juju_agent')
@@ -222,8 +220,7 @@ class TalismanTest(unittest.TestCase):
         juju_agent.return_value = {}
         t.wait(self.timeout)
 
-    @patch('sys.stderr.write', Mock())
-    @patch('amulet.helpers.juju', Mock(side_effect=lambda c: ' '.join(c)))
+    @patch('amulet.helpers.juju', Mock(return_value='status'))
     @patch('amulet.helpers.default_environment', Mock())
     @patch('amulet.waiter.status')
     def test_wait_for_messages(self, _status):

--- a/tests/test_waiter.py
+++ b/tests/test_waiter.py
@@ -9,7 +9,7 @@ from amulet import waiter
 from amulet.helpers import TimeoutError, JujuVersion
 from .helper import JujuStatus
 
-from mock import patch
+from mock import patch, Mock
 
 
 class WaiterTest(unittest.TestCase):
@@ -187,12 +187,13 @@ class WaitTest(unittest.TestCase):
 
         self.assertTrue(wait(juju_env='dummy', timeout=1))
 
+    @patch('sys.stderr.write', Mock())
+    @patch('amulet.helpers.juju', Mock())
     @patch('amulet.waiter.state')
     def test_wait_exception(self, waiter_status):
-        waiter_status.side_effect = [Exception,
-                                     TimeoutError]
+        waiter_status.side_effect = waiter.StateError
 
-        self.assertRaises(TimeoutError, wait, juju_env='dummy')
+        self.assertRaises(TimeoutError, wait, juju_env='dummy', timeout=0.01)
 
 
 class StatusTest(unittest.TestCase):

--- a/tests/test_waiter.py
+++ b/tests/test_waiter.py
@@ -187,8 +187,7 @@ class WaitTest(unittest.TestCase):
 
         self.assertTrue(wait(juju_env='dummy', timeout=1))
 
-    @patch('sys.stderr.write', Mock())
-    @patch('amulet.helpers.juju', Mock())
+    @patch('amulet.helpers.juju', Mock(return_value='status'))
     @patch('amulet.waiter.state')
     def test_wait_exception(self, waiter_status):
         waiter_status.side_effect = waiter.StateError


### PR DESCRIPTION
Leveraging the new workload-status and agent-status, we can now tell with more certainty whether the system has settled down.  On top of this, wait_for_messages allows charm-specific matching on extended status messages.

Also refactored timeout logic in some portions to make testing faster and easier to debug.

Also fixed lint errors.