### PR TITLE
Wait changes: add_unit & wait_for_statuses

### DIFF
--- a/amulet/helpers.py
+++ b/amulet/helpers.py
@@ -102,10 +102,11 @@ def timeout_gen(seconds):
     i = 0
     while True:
         yield i
-        if (datetime.now() - start).total_seconds() > seconds:
+        elapsed = (datetime.now() - start).total_seconds()
+        if elapsed > seconds:
             sys.stderr.write('Timeout occurred, printing juju status...')
             sys.stderr.write(juju(['status']))
-            raise TimeoutError()
+            raise TimeoutError('Timed out after %s seconds' % int(elapsed))
         i += 1
 
 

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -210,6 +210,7 @@ class DeployerTests(unittest.TestCase):
         with patch('amulet.deployer.juju') as j:
             d.add_unit('charm')
             j.assert_called_with(['add-unit', 'charm', '-n', '1'])
+        d.sentry.discover_units()
         self.assertTrue('charm/1' in d.sentry.unit)
         self.assertEqual(2, d.services['charm']['num_units'])
 
@@ -275,9 +276,10 @@ class DeployerTests(unittest.TestCase):
         d.add('charm', units=1)
         d.setup()
         with patch('amulet.deployer.juju'):
+            d.add_unit('charm')
             self.assertRaisesRegexp(
                 Exception, 'Error on unit charm/1: hook failed: install',
-                d.add_unit, 'charm')
+                d.sentry.wait_for_status, 'env', ['charm'], timeout=0.01)
 
     @patch('amulet.charm.CharmCache.get_charm')
     def test_remove_unit(self, get_charm):


### PR DESCRIPTION
Removed implicit wait from add_unit (fixes #105 though it may need test changes to ensure proper wait).

Also added wait_for_statuses to wait against workload statuses to go along with waiting against workload status messages.
