### PR TITLE
Make sentry lookup failures explicit

### DIFF
--- a/amulet/sentry.py
+++ b/amulet/sentry.py
@@ -233,6 +233,11 @@ class Talisman(object):
         If the second form is used, a single object, the UnitSentry for
         the specified unit, is returned.
 
+        Raises a KeyError if the unit does not exist.
+
+        Returns an empty list if the service does not exist or has
+        no units.
+
         Examples::
 
             >>> d
@@ -252,21 +257,13 @@ class Talisman(object):
             >>>
 
         """
-        single_unit = '/' in service
-
-        def match(service, unit_name):
-            if single_unit:
-                return service == unit_name
-            return service == unit_name.split('/')[0]
-
-        unit_sentries = [unit_sentry
-                         for unit_name, unit_sentry in self.unit.items()
-                         if match(service, unit_name)]
-
-        if single_unit and unit_sentries:
-            return unit_sentries[0]
-
-        return unit_sentries
+        if '/' in service:
+            unit_name = service
+            return self.unit[unit_name]
+        else:
+            return [unit_sentry
+                    for unit_name, unit_sentry in self.unit.items()
+                    if service == unit_name.split('/', 1)[0]]
 
     def get_status(self, juju_env=None):
         """

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -200,6 +200,15 @@ class TalismanTest(unittest.TestCase):
         self.assertEqual(sentry['meteor/0'], sentry.unit['meteor/0'])
         self.assertEqual(sentry['meteor'], list(sentry.unit.values()))
 
+        with self.assertRaises(KeyError):
+            sentry['meteor/99']  # Non-existent unit.
+
+        # Non-existent service, or service with no units.
+        self.assertEqual(sentry['invalid'], [])
+
+        with self.assertRaises(KeyError):
+            sentry['invalid/99']  # Non-existent unit in non-existent service.
+
     @patch.object(Talisman, 'wait_for_status')
     @patch.object(UnitSentry, 'upload_scripts')
     @patch('amulet.sentry.helpers.default_environment')


### PR DESCRIPTION
Looking up a sentry for a unit that doesn't exist gives a horribly confusing error message, rather than a KeyError like it should.

Previously such a trivial fix nobody bothered to do so, it is more important now that this failure is being triggered a lot more in tests due to Juju 1.25 unit naming changes.