### PR TITLE
Return sentry list in a stable order

### DIFF
--- a/amulet/sentry.py
+++ b/amulet/sentry.py
@@ -262,7 +262,7 @@ class Talisman(object):
             return self.unit[unit_name]
         else:
             return [unit_sentry
-                    for unit_name, unit_sentry in self.unit.items()
+                    for unit_name, unit_sentry in sorted(self.unit.items())
                     if service == unit_name.split('/', 1)[0]]
 
     def get_status(self, juju_env=None):

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -198,7 +198,7 @@ class TalismanTest(unittest.TestCase):
         sentry = Talisman(['meteor'], timeout=self.timeout)
 
         self.assertEqual(sentry['meteor/0'], sentry.unit['meteor/0'])
-        self.assertEqual(sentry['meteor'], list(sentry.unit.values()))
+        self.assertSetEqual(set(sentry['meteor']), set(sentry.unit.values()))
 
         with self.assertRaises(KeyError):
             sentry['meteor/99']  # Non-existent unit.


### PR DESCRIPTION
Per comments on last landing, return the sentry list in a stable order.