### PR TITLE
Pass timeouts via env vars.

### DIFF
--- a/amulet/deployer.py
+++ b/amulet/deployer.py
@@ -590,6 +590,8 @@ class Deployment(object):
             :class:`amulet.helpers.TimeoutError`.
 
         :param timeout: Amount of time to wait for deployment to complete.
+            If environment variable AMULET_SETUP_TIMEOUT is set, it overrides
+            this value.
         :param cleanup: Set to False to leave the generated deployer file
             on disk. Useful for debugging.
 
@@ -608,6 +610,8 @@ class Deployment(object):
                 pass
 
         """
+        timeout = int(os.environ.get('AMULET_SETUP_TIMEOUT') or timeout)
+
         if not self.deployer:
             raise NameError('Path to juju-deployer is not defined.')
 

--- a/amulet/sentry.py
+++ b/amulet/sentry.py
@@ -424,10 +424,13 @@ class Talisman(object):
 
         :param str juju_env: Name of the juju environment.
         :param dict services: Dictionary of services in the environment.
-        :param int timeout: Time to wait before timing out.
+        :param int timeout: Time to wait before timing out. If environment
+            variable AMULET_WAIT_TIMEOUT is set, it overrides this value.
         :return: Dictionary of juju enviroment status.
 
         """
+        timeout = int(os.environ.get('AMULET_WAIT_TIMEOUT') or timeout)
+
         def check_status(juju_env, services):
             status = self.get_status(juju_env)
             for service_name in services:
@@ -462,9 +465,13 @@ class Talisman(object):
         """Wait for all units to finish running hooks.
 
         :param int timeout: Number of seconds to wait before timing-out.
+            If environment variable AMULET_WAIT_TIMEOUT is set, it overrides
+            this value.
         :raises: :class:`amulet.TimeoutError` if the timeout is exceeded.
 
         """
+        timeout = int(os.environ.get('AMULET_WAIT_TIMEOUT') or timeout)
+
         def check_status():
             status = self.get_status()
             for service_name in self.service_names:


### PR DESCRIPTION
AMULET_SETUP_TIMEOUT - If set, overrides the value passed to Deployment.setup()
AMULET_WAIT_TIMEOUT - If set, overrides the value passed to Deployment().sentry.wait()

Fixes #119.