### PR TITLE
Save juju status on Talisman

### DIFF
--- a/amulet/sentry.py
+++ b/amulet/sentry.py
@@ -309,13 +309,15 @@ class Talisman(object):
 
         self.juju_env = juju_env or helpers.default_environment()
 
-        status = self.wait_for_status(self.juju_env, services, timeout)
+        # Save the juju status so we can inspect it later if we don't
+        # end up with what we expect in our dictionary of sentries.
+        self.status = self.wait_for_status(self.juju_env, services, timeout)
 
         for service in services:
-            if service not in status['services']:
+            if service not in self.status['services']:
                 continue  # Raise something?
 
-            service_status = status['services'][service]
+            service_status = self.status['services'][service]
 
             if 'units' not in service_status:
                 continue


### PR DESCRIPTION
I haven't been able to repro #122, so I'm adding a way to debug when it happens again. Now we can print sentry.status and find out why we don't have the sentries we were expecting, e.g.:

```python
try:
    lxd1_sentry = self.d.sentry['lxd'][1]
except KeyError, IndexError:
    print(sentry.status)  # or something
```

Would be nice to get a patch release of this in ppa:juju/stable if possible so it can be used in OSCI.