### PR TITLE
Add support for https://github.com

### DIFF
--- a/amulet/charm.py
+++ b/amulet/charm.py
@@ -33,8 +33,8 @@ class CharmCache(dict):
                 series
             )
 
-        if (branch and (branch.endswith('.git') or
-                branch.startswith('https://github.com'))):
+        if (charm_path.endswith('.git') or
+                charm_path.startswith('https://github.com')):
             return GitCharm(branch, name=charm_path)
 
         if os.path.exists(os.path.expanduser(charm_path)):

--- a/amulet/charm.py
+++ b/amulet/charm.py
@@ -35,7 +35,7 @@ class CharmCache(dict):
 
         if (charm_path.endswith('.git') or
                 charm_path.startswith('https://github.com')):
-            return GitCharm(branch, name=charm_path)
+            return GitCharm(charm_path)
 
         if os.path.exists(os.path.expanduser(charm_path)):
             return LocalCharm(charm_path, series)

--- a/amulet/charm.py
+++ b/amulet/charm.py
@@ -33,8 +33,8 @@ class CharmCache(dict):
                 series
             )
 
-        if (branch and branch.endswith('.git') or
-                branch.startswith('https://github.com')):
+        if (branch and (branch.endswith('.git') or
+                branch.startswith('https://github.com'))):
             return GitCharm(branch, name=charm_path)
 
         if os.path.exists(os.path.expanduser(charm_path)):


### PR DESCRIPTION
Amulet does not detected repositories on https://github.com as
Git repositories; add check for this prefix and add support for
providing a branch using the format:

    <git repository url>;<branch>

This is required to support migration of OpenStack Amulet testing
to directly use new github.com source locations.