### PR TITLE
Importing path differently to avoid deprecation warnings.

### DIFF
--- a/amulet/charm.py
+++ b/amulet/charm.py
@@ -9,7 +9,7 @@ import yaml
 from .helpers import reify
 from .helpers import run_bzr
 from charmstore import Charm
-from path import path
+from path import Path as path
 from path import tempdir
 
 

--- a/amulet/deployer.py
+++ b/amulet/deployer.py
@@ -8,7 +8,7 @@ import subprocess
 import warnings
 import yaml
 
-from path import path
+from path import Path as path
 from path import tempdir
 
 from . import actions


### PR DESCRIPTION
Removing the deprecated method of importing from path.py.  The class name is "Path" and we can import that as "path" so there are no further code changes and now no deprecation warnings.

Fixes #158 
