### PR TITLE
Honor JUJU_MODEL environment variable.

### DIFF
--- a/amulet/helpers.py
+++ b/amulet/helpers.py
@@ -189,7 +189,9 @@ def raise_status(code, msg=None):
 
 
 def default_environment():
-    return subprocess.check_output(['juju', 'switch']).strip().decode('utf8')
+    return os.getenv(
+        'JUJU_MODEL',
+        subprocess.check_output(['juju', 'switch']).strip().decode('utf8'))
 
 
 class reify(object):


### PR DESCRIPTION
Not honoring JUJU_MODEL env variable is one of the causes of juju-solutions/bundletester#93 issue. If JUJU_MODEL env is set, Amulet needs to use the controller and model specified by the env variable rather than the output from the`juju switch` command. When working with multiple controllers, `juju switch` might have undesired result.