### PR TITLE
(Hopefully) fix scp timeout by being explicit about model and retrying

### DIFF
--- a/amulet/helpers.py
+++ b/amulet/helpers.py
@@ -58,8 +58,8 @@ def run_bzr(args, working_dir, env=None):
     return _as_text(out)
 
 
-def juju(args, env=None, include_env=True):
-    if include_env:
+def juju(args, env=None, include_model=True):
+    if include_model:
         model_flag = '-m' if JUJU_VERSION.major == 2 else '-e'
         for arg in args:
             if arg.startswith(model_flag):
@@ -165,9 +165,9 @@ class JujuVersion(object):
 
     def get_version(self):
         try:
-            version = juju(['version'], include_env=False)
+            version = juju(['version'], include_model=False)
         except:
-            version = juju(['--version'], include_env=False)
+            version = juju(['--version'], include_model=False)
 
         self.update_version(self.parse_version(version))
 
@@ -211,7 +211,7 @@ def default_environment():
     if not model:
         model = os.getenv('JUJU_ENV')
     if not model:
-        model = juju(['switch'], include_env=False).strip()
+        model = juju(['switch'], include_model=False).strip()
     return model
 
 

--- a/amulet/helpers.py
+++ b/amulet/helpers.py
@@ -189,9 +189,22 @@ def raise_status(code, msg=None):
 
 
 def default_environment():
-    return os.getenv(
-        'JUJU_MODEL',
-        subprocess.check_output(['juju', 'switch']).strip().decode('utf8'))
+    """
+    Get the current active (default) Juju model / environment.
+
+    It will check, in order of preference:
+
+    * The JUJU_MODEL environment variable
+    * The JUJU_ENV environment variable
+    * The output of `juju switch`
+    """
+    model = os.getenv('JUJU_MODEL')
+    if not model:
+        model = os.getenv('JUJU_ENV')
+    if not model:
+        model = subprocess.check_output(['juju', 'switch'])
+        model = model.strip().decode('utf8')
+    return model
 
 
 class reify(object):

--- a/amulet/waiter.py
+++ b/amulet/waiter.py
@@ -17,7 +17,7 @@ def wait(*args, **kwargs):
     """Wait until all criteria is met for a given juju environment
 
     When run without parameters the following defaults are used:
-      - juju_env = os.environ['JUJU_ENV']
+      - juju_env = amulet.helpers.default_environment()
       - timeout = 300 (5m)
       - Wait will pause execution and wait for ALL units to move to a non-error
       state.
@@ -28,11 +28,8 @@ def wait(*args, **kwargs):
       amulet.wait('service_a', 'service_a/1')
 
     """
-    import os
-
     if 'juju_env' not in kwargs:
-        kwargs['juju_env'] = \
-            os.environ.get('JUJU_ENV') or default_environment()
+        kwargs['juju_env'] = default_environment()
 
     if 'timeout' not in kwargs:
         kwargs['timeout'] = 300

--- a/tests/functional/test_sentry.py
+++ b/tests/functional/test_sentry.py
@@ -7,10 +7,10 @@ class TestDeployment(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.deployment = amulet.Deployment(series='precise')
+        cls.deployment = amulet.Deployment(series='trusty')
 
         cls.deployment.add('nagios')
-        cls.deployment.add('haproxy', charm='cs:~marcoceppi/precise/haproxy-0')
+        cls.deployment.add('haproxy')
         cls.deployment.add('rsyslog-forwarder')
         cls.deployment.relate('nagios:website', 'haproxy:reverseproxy')
         cls.deployment.relate(
@@ -60,7 +60,7 @@ class TestDeployment(unittest.TestCase):
                 'size': 9,
                 'uid': 0,
                 'gid': 0,
-                'mode': '0100644',
+                'mode': '0o100644',
             },
         )
         stat = self.nagios.file_stat('metadata.yaml')
@@ -98,7 +98,7 @@ class TestDeployment(unittest.TestCase):
                 'size': stat['size'],
                 'uid': 0,
                 'gid': 0,
-                'mode': '040700',
+                'mode': '0o40700',
             },
         )
         stat = self.nagios.directory_stat('hooks')
@@ -123,7 +123,8 @@ class TestDeployment(unittest.TestCase):
 
         haproxy_info = self.haproxy.relation(
             'reverseproxy', 'nagios:website')
-        self.assertEqual(list(haproxy_info.keys()), ['private-address'])
+        self.assertEqual(set(haproxy_info.keys()), {'private-address',
+                                                    'public-address'})
 
     def test_run(self):
         self.assertEqual(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,7 +8,6 @@ import time
 from amulet.helpers import (
     JujuVersion,
     environments,
-    default_environment,
     juju,
     raise_status,
     timeout_gen,
@@ -49,7 +48,7 @@ class HelpersTest(unittest.TestCase):
         self.assertEqual(version.patch, 3)
         self.assertEqual(str(version), '1.2.3')
 
-        mj.assert_called_with(['version'])
+        mj.assert_called_with(['version'], include_env=False)
 
     @patch('amulet.helpers.juju')
     def test_jujuversion_py(self, mj):
@@ -61,7 +60,7 @@ class HelpersTest(unittest.TestCase):
         self.assertEqual(version.patch, None)
         self.assertEqual(str(version), '8.6')
 
-        mj.assert_called_with(['--version'])
+        mj.assert_called_with(['--version'], include_env=False)
 
     @patch('amulet.helpers.juju')
     def test_jujuversion_malformed(self, mj):
@@ -73,7 +72,7 @@ class HelpersTest(unittest.TestCase):
         self.assertEqual(version.patch, 3)
         self.assertEqual(str(version), '1.2.3')
 
-        mj.assert_called_once_with(['version'])
+        mj.assert_called_once_with(['version'], include_env=False)
 
     @patch('os.path.isfile')
     @patch('builtins.open' if sys.version_info > (3,) else '__builtin__.open')
@@ -105,7 +104,9 @@ class HelpersTest(unittest.TestCase):
 
 class JujuTest(unittest.TestCase):
     def test_juju(self):
-        self.assertEqual(str(JujuVersion()), juju(['version']).split('-')[0])
+        self.assertEqual(str(JujuVersion()),
+                         juju(['version'],
+                              include_env=False).split('-')[0])
 
     @patch('amulet.helpers.subprocess.Popen')
     def test_juju_oserror(self, mp):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -48,7 +48,7 @@ class HelpersTest(unittest.TestCase):
         self.assertEqual(version.patch, 3)
         self.assertEqual(str(version), '1.2.3')
 
-        mj.assert_called_with(['version'], include_env=False)
+        mj.assert_called_with(['version'], include_model=False)
 
     @patch('amulet.helpers.juju')
     def test_jujuversion_py(self, mj):
@@ -60,7 +60,7 @@ class HelpersTest(unittest.TestCase):
         self.assertEqual(version.patch, None)
         self.assertEqual(str(version), '8.6')
 
-        mj.assert_called_with(['--version'], include_env=False)
+        mj.assert_called_with(['--version'], include_model=False)
 
     @patch('amulet.helpers.juju')
     def test_jujuversion_malformed(self, mj):
@@ -72,7 +72,7 @@ class HelpersTest(unittest.TestCase):
         self.assertEqual(version.patch, 3)
         self.assertEqual(str(version), '1.2.3')
 
-        mj.assert_called_once_with(['version'], include_env=False)
+        mj.assert_called_once_with(['version'], include_model=False)
 
     @patch('os.path.isfile')
     @patch('builtins.open' if sys.version_info > (3,) else '__builtin__.open')
@@ -106,7 +106,7 @@ class JujuTest(unittest.TestCase):
     def test_juju(self):
         self.assertEqual(str(JujuVersion()),
                          juju(['version'],
-                              include_env=False).split('-')[0])
+                              include_model=False).split('-')[0])
 
     @patch('amulet.helpers.subprocess.Popen')
     def test_juju_oserror(self, mp):


### PR DESCRIPTION
In an attempt to fix #170, this improves the robustness of the scp process by explicitly specifying the model on the command line (to avoid having the active model switched out from under it) and retrying the ssh / scp commands a couple of times (to address transient network issues).