### PR TITLE
#:178 Fix model/env flag placement

### DIFF
--- a/amulet/helpers.py
+++ b/amulet/helpers.py
@@ -67,7 +67,7 @@ def juju(args, env=None, include_model=True):
         else:
             args = list(args)
             # insert the model arg after the command, but before any other args
-            args[1:0] = [model_flag, default_environment()]
+            args += [model_flag, default_environment()]
     try:
         p = subprocess.Popen(['juju'] + args, env=env, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)


### PR DESCRIPTION
 * The current placement of the model/env flag breaks juju 1.x actions
 * The -m/-e flag can be placed at the end of the command
 * Tested with juju 1.x and 2.x