### PR TITLE
Fix model flag placement for Juju 1 compound commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
-language: python
+dist: trusty
 sudo: required
+language: python
 python:
   - "2.7"
-  - "3.3"
+  - "3.5"
 before_install:
+  - sudo add-apt-repository ppa:ubuntu-lxc/lxd-stable -y
   - sudo add-apt-repository -y ppa:juju/stable
   - sudo apt-get update
-  - sudo apt-get install juju bzr
+  - sudo apt-get install -y lxd juju bzr
+  - sudo usermod -a -G lxd $USER
+  - sudo lxd init --auto
   - echo 'NAME="Ubuntu"' | sudo tee /etc/os-release
   - echo 'VERSION="14.04.2 LTS, Trusty Tahr"' | sudo tee -a /etc/os-release
   - echo 'ID=ubuntu' | sudo tee -a /etc/os-release
@@ -15,6 +19,10 @@ before_install:
   - echo 'VERSION_ID="14.04"' | sudo tee -a /etc/os-release
   - echo 'HOME_URL="http://www.ubuntu.com/"' | sudo tee -a /etc/os-release
 install: "pip install -e .; pip install -r test-requires.txt; pip install python-coveralls"
-script: "nosetests --nologcapture --with-coverage --cover-package=amulet -e functional"
+before_script:
+  - sudo -E sudo -u $USER -E bash -c "juju bootstrap localhost test"
+script: "nosetests --nologcapture --with-coverage --cover-package=amulet"
 after_success:
   - coveralls
+after_script:
+  - sudo -E sudo -u $USER -E bash -c "juju destroy-controller --destroy-all-models -y test"

--- a/amulet/helpers.py
+++ b/amulet/helpers.py
@@ -65,9 +65,9 @@ def juju(args, env=None, include_model=True):
             if arg.startswith(model_flag):
                 break
         else:
-            args = list(args)
-            # insert the model arg after the command, but before any other args
-            args[1:0] = [model_flag, default_environment()]
+            if env is None:
+                env = os.environ
+            env['JUJU_ENV'] = env['JUJU_MODEL'] = default_environment()
     try:
         p = subprocess.Popen(['juju'] + args, env=env, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)

--- a/amulet/helpers.py
+++ b/amulet/helpers.py
@@ -63,14 +63,9 @@ def run_bzr(args, working_dir, env=None):
 
 def juju(args, env=None, include_model=True):
     if include_model:
-        model_flag = '-m' if JUJU_VERSION.major == 2 else '-e'
-        for arg in args:
-            if arg.startswith(model_flag):
-                break
-        else:
-            if env is None:
-                env = os.environ
-            env['JUJU_ENV'] = env['JUJU_MODEL'] = default_environment()
+        if env is None:
+            env = os.environ
+        env['JUJU_ENV'] = env['JUJU_MODEL'] = default_environment()
     try:
         p = subprocess.Popen(['juju'] + args, env=env, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)

--- a/amulet/helpers.py
+++ b/amulet/helpers.py
@@ -15,6 +15,9 @@ SKIP = 100
 PASS = 0
 FAIL = 1
 
+JUJU_VERSION = None  # will be set below
+JUJU_MODEL = None  # will be set below
+
 
 class TimeoutError(Exception):
     def __init__(self, value="Timed Out"):
@@ -207,11 +210,17 @@ def default_environment():
     * The JUJU_ENV environment variable
     * The output of `juju switch`
     """
+    global JUJU_MODEL
+    if JUJU_MODEL is not None:
+        return JUJU_MODEL
     model = os.getenv('JUJU_MODEL')
     if not model:
         model = os.getenv('JUJU_ENV')
     if not model:
         model = juju(['switch'], include_model=False).strip()
+    # cache the active environment to ensure the
+    # same one is used for the entire test run
+    JUJU_MODEL = model
     return model
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,6 +8,7 @@ import time
 from amulet.helpers import (
     JujuVersion,
     environments,
+    default_environment,
     juju,
     raise_status,
     timeout_gen,
@@ -100,6 +101,15 @@ class HelpersTest(unittest.TestCase):
                     return
         self.assertRaises(TimeoutError, case, 0.1)
         case(0.5)
+
+    @patch('amulet.helpers.juju')
+    @patch('amulet.helpers.JUJU_MODEL', None)
+    @patch('os.environ', {})
+    def test_default_env_cache(self, juju):
+        juju.return_value = 'test-env'
+        self.assertEqual(default_environment(), 'test-env')
+        juju.return_value = 'new-env'
+        self.assertEqual(default_environment(), 'test-env')
 
 
 class JujuTest(unittest.TestCase):

--- a/tests/test_waiter.py
+++ b/tests/test_waiter.py
@@ -153,6 +153,7 @@ class WaitTest(unittest.TestCase):
         tout.side_effect = TimeoutError
         self.assertRaises(TimeoutError, wait, juju_env='dummy')
 
+    @patch('amulet.helpers.JUJU_MODEL', None)
     @patch('amulet.waiter.state')
     @patch.dict('os.environ', {'JUJU_ENV': 'testing-env', 'JUJU_MODEL': ''})
     def test_wait_juju_env(self, waiter_status):
@@ -160,6 +161,7 @@ class WaitTest(unittest.TestCase):
         wait()
         waiter_status.assert_called_with(juju_env='testing-env')
 
+    @patch('amulet.helpers.JUJU_MODEL', None)
     @patch('amulet.waiter.state')
     @patch.dict('os.environ', {'JUJU_MODEL': 'testing-env', 'JUJU_ENV': 'foo'})
     def test_wait_juju_model(self, waiter_status):

--- a/tests/test_waiter.py
+++ b/tests/test_waiter.py
@@ -154,8 +154,15 @@ class WaitTest(unittest.TestCase):
         self.assertRaises(TimeoutError, wait, juju_env='dummy')
 
     @patch('amulet.waiter.state')
-    @patch.dict('os.environ', {'JUJU_ENV': 'testing-env'})
+    @patch.dict('os.environ', {'JUJU_ENV': 'testing-env', 'JUJU_MODEL': ''})
     def test_wait_juju_env(self, waiter_status):
+        waiter_status.return_value = {'test': {'0': 'started'}}
+        wait()
+        waiter_status.assert_called_with(juju_env='testing-env')
+
+    @patch('amulet.waiter.state')
+    @patch.dict('os.environ', {'JUJU_MODEL': 'testing-env', 'JUJU_ENV': 'foo'})
+    def test_wait_juju_model(self, waiter_status):
         waiter_status.return_value = {'test': {'0': 'started'}}
         wait()
         waiter_status.assert_called_with(juju_env='testing-env')


### PR DESCRIPTION
Use env vars to be explicit about the model.  (Fixes #178)

The placement of the CLI arg for specifying the model is complicated by the fact that Juju 1 has compound commands (such as `juju action do`) while other commands have to have the arg as early as possible (e.g., `juju scp` passes later args through to scp).  The env vars will override the active environment from the state file.

This also adds functional testing to the Travis config for Juju 2.  I'm not sure of a clean way to force it to use `juju-1` even if we install that, but I'm open to ideas.