### PR TITLE
Test with Juju 1.x as well as 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 before_script:
   - ./.travis/bootstrap.sh
 script:
-  - nosetests --nologcapture --with-coverage --cover-package=amulet
+  - nosetests -v --nologcapture --with-coverage --cover-package=amulet
 after_success:
   - coveralls
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,20 @@
 dist: trusty
 sudo: required
 language: python
-python:
-  - "2.7"
-  - "3.5"
-before_install:
-  - sudo add-apt-repository ppa:ubuntu-lxc/lxd-stable -y
-  - sudo add-apt-repository -y ppa:juju/stable
-  - sudo apt-get update
-  - sudo apt-get install -y lxd juju bzr
-  - sudo usermod -a -G lxd $USER
-  - sudo lxd init --auto
-  - echo 'NAME="Ubuntu"' | sudo tee /etc/os-release
-  - echo 'VERSION="14.04.2 LTS, Trusty Tahr"' | sudo tee -a /etc/os-release
-  - echo 'ID=ubuntu' | sudo tee -a /etc/os-release
-  - echo 'ID_LIKE=debian' | sudo tee -a /etc/os-release
-  - echo 'PRETTY_NAME="Ubuntu 14.04.2 LTS"' | sudo tee -a /etc/os-release
-  - echo 'VERSION_ID="14.04"' | sudo tee -a /etc/os-release
-  - echo 'HOME_URL="http://www.ubuntu.com/"' | sudo tee -a /etc/os-release
-install: "pip install -e .; pip install -r test-requires.txt; pip install python-coveralls"
+matrix:
+  include:
+    - python: 2.7
+      env: JUJU_VERSION=1
+    - python: 3.5
+      env: JUJU_VERSION=2
+install:
+  - .travis/install.sh
+  - pip install -r test-requires.txt python-coveralls -e .
 before_script:
-  - sudo -E sudo -u $USER -E bash -c "juju bootstrap localhost test"
-script: "nosetests --nologcapture --with-coverage --cover-package=amulet"
+  - ./.travis/bootstrap.sh
+script:
+  - nosetests --nologcapture --with-coverage --cover-package=amulet
 after_success:
   - coveralls
 after_script:
-  - sudo -E sudo -u $USER -E bash -c "juju destroy-controller --destroy-all-models -y test"
+  - ./.travis/cleanup.sh

--- a/.travis/bootstrap.sh
+++ b/.travis/bootstrap.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-set -e
+#!/bin/bash -uex
 
 if [[ $JUJU_VERSION == 2 ]]; then
     # the "sudo sudo bash" is to ensure that the lxd group is active

--- a/.travis/bootstrap.sh
+++ b/.travis/bootstrap.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+if [[ $JUJU_VERSION == 2 ]]; then
+    # the "sudo sudo bash" is to ensure that the lxd group is active
+    sudo -E sudo -u $USER -E bash -c "juju bootstrap localhost test"
+else
+    juju generate-config
+    juju switch local
+    juju bootstrap
+fi

--- a/.travis/cleanup.sh
+++ b/.travis/cleanup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+if [[ $JUJU_VERSION == 2 ]]; then
+    # the "sudo sudo bash" is to ensure that the lxd group is active
+    sudo -E sudo -u $USER -E bash -c "juju destroy-controller --destroy-all-models -y test"
+else
+    juju destroy-environment --force
+fi

--- a/.travis/cleanup.sh
+++ b/.travis/cleanup.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-set -e
+#!/bin/bash -uex
 
 if [[ $JUJU_VERSION == 2 ]]; then
     # the "sudo sudo bash" is to ensure that the lxd group is active

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-set -e
+#!/bin/bash -uex
 
 cat << EOR | sudo tee -a /etc/os-release
 NAME="Ubuntu"
@@ -17,6 +15,7 @@ if [[ $JUJU_VERSION == 2 ]]; then
     sudo add-apt-repository -y ppa:ubuntu-lxc/lxd-stable
     JUJU_PKGS="juju lxd"
 else
+    sudo add-apt-repository -y ppa:juju/1.25
     JUJU_PKGS="juju juju-local"
 fi
 

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+cat << EOR | sudo tee -a /etc/os-release
+NAME="Ubuntu"
+VERSION="14.04.2 LTS, Trusty Tahr"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 14.04.2 LTS"
+VERSION_ID="14.04"
+HOME_URL="http://www.ubuntu.com/"
+EOR
+
+if [[ $JUJU_VERSION == 2 ]]; then
+    sudo add-apt-repository -y ppa:juju/stable
+    sudo add-apt-repository -y ppa:ubuntu-lxc/lxd-stable
+    JUJU_PKGS="juju lxd"
+else
+    JUJU_PKGS="juju juju-local"
+fi
+
+sudo apt-get update
+sudo apt-get install -y bzr $JUJU_PKGS
+
+if [[ $JUJU_VERSION == 2 ]]; then
+    echo User: $USER
+    sudo usermod -a -G lxd $USER
+    sudo lxd init --auto
+fi


### PR DESCRIPTION
This tests Juju 1.x when testing Python 2.7 and 2.x when testing Python 3.5.  It would be more complete to test both versions of Juju with each version of Python, but that would make the tests take twice as long and I don't think there's really any cross-dependency between the Python version and Juju version.