### PR TITLE
Increase travis test verbosity and use the stable PPA when testing Juju 1.25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 before_script:
   - ./.travis/bootstrap.sh
 script:
-  - nosetests --nologcapture --with-coverage --cover-package=amulet
+  - nosetests -v --nologcapture --with-coverage --cover-package=amulet
 after_success:
   - coveralls
 after_script:

--- a/.travis/bootstrap.sh
+++ b/.travis/bootstrap.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-set -e
+#!/bin/bash -uex
 
 if [[ $JUJU_VERSION == 2 ]]; then
     # the "sudo sudo bash" is to ensure that the lxd group is active

--- a/.travis/cleanup.sh
+++ b/.travis/cleanup.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-set -e
+#!/bin/bash -uex
 
 if [[ $JUJU_VERSION == 2 ]]; then
     # the "sudo sudo bash" is to ensure that the lxd group is active

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -15,6 +15,7 @@ if [[ $JUJU_VERSION == 2 ]]; then
     sudo add-apt-repository -y ppa:ubuntu-lxc/lxd-stable
     JUJU_PKGS="juju lxd"
 else
+    sudo add-apt-repository -y ppa:juju/1.25
     JUJU_PKGS="juju juju-local"
 fi
 

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-set -e
+#!/bin/bash -uex
 
 cat << EOR | sudo tee -a /etc/os-release
 NAME="Ubuntu"


### PR DESCRIPTION
- Use Juju stable ppa when testing 1.25 to ensure current version is exercised.

- Show nose test names and verdict.  Provides relevance to stderr output that might also exist (such as the wait test timeout messages).

- Show bash commands as executed in test runner.

- Require referenced env vars in test runner to exist.
